### PR TITLE
Minimal template for a custom Girder-based web client app

### DIFF
--- a/hello_app/Gruntfile.js
+++ b/hello_app/Gruntfile.js
@@ -1,0 +1,71 @@
+module.exports = function (grunt) {
+    var fs = require('fs');
+    var defaultTasks = [];
+    var pluginName = 'hello_app';
+    var pluginDir = 'plugins/hello_app';
+    var staticDir = 'clients/web/static/built/plugins/' + pluginName;
+    var sourceDir = 'web_external';
+
+    if (!fs.existsSync(staticDir)) {
+        fs.mkdirSync(staticDir);
+    }
+
+    var jadeDir = pluginDir + '/' + sourceDir + '/templates';
+    if (fs.existsSync(jadeDir)) {
+        var files = {};
+        files[staticDir + '/templates.js'] = [jadeDir + '/**/*.jade'];
+        grunt.config.set('jade.' + pluginName, {
+            files: files
+        });
+        grunt.config.set('jade.' + pluginName + '.options', {
+            namespace: pluginName + '.templates'
+        });
+        grunt.config.set('watch.jade_' + pluginName, {
+            files: [jadeDir + '/**/*.jade'],
+            tasks: ['jade:' + pluginName, 'uglify:' + pluginName]
+        });
+        defaultTasks.push('jade:' + pluginName);
+    }
+
+    var cssDir = pluginDir + '/' + sourceDir + '/stylesheets';
+    if (fs.existsSync(cssDir)) {
+        var files = {};
+        files[staticDir + '/' + pluginName + '.min.css'] = [cssDir + '/**/*.styl'];
+        grunt.config.set('stylus.' + pluginName, {
+            files: files
+        });
+        grunt.config.set('watch.stylus_' + pluginName, {
+            files: [cssDir + '/**/*.styl'],
+            tasks: ['stylus:' + pluginName]
+        });
+        defaultTasks.push('stylus:' + pluginName);
+    }
+
+    var jsDir = pluginDir + '/' + sourceDir + '/js';
+    if (fs.existsSync(jsDir)) {
+        var files = {};
+        files[staticDir + '/' + pluginName + '.min.js'] = [
+            jsDir + '/init.js',
+            staticDir + '/templates.js',
+            jsDir + '/view.js',
+            jsDir + '/app.js',
+            jsDir + '/utilities.js',
+            jsDir + '/models/**/*.js',
+            jsDir + '/collections/**/*.js',
+            jsDir + '/views/**/*.js'
+        ];
+        files[staticDir + '/main.min.js'] = [
+            jsDir + '/main.js'
+        ];
+        grunt.config.set('uglify.' + pluginName, {
+            files: files
+        });
+        grunt.config.set('watch.js_' + pluginName, {
+            files: [jsDir + '/**/*.js'],
+            tasks: ['uglify:' + pluginName]
+        });
+        defaultTasks.push('uglify:' + pluginName);
+    }
+
+    grunt.registerTask('hello-app', defaultTasks);
+};

--- a/hello_app/plugin.json
+++ b/hello_app/plugin.json
@@ -1,0 +1,14 @@
+{
+    "name": "Hello world application",
+    "description": "A minimal template for a custom Girder front-end application",
+    "version": "0.1.0",
+    "dependencies": [
+        "gravatar"
+    ],
+    "grunt": {
+        "file": "Gruntfile.js",
+        "defaultTargets": [
+            "hello-app"
+        ]
+    }
+}

--- a/hello_app/server/__init__.py
+++ b/hello_app/server/__init__.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import mako
+from .hello_rest import Hello
+
+
+class CustomAppRoot(object):
+    """
+    This serves the main index HTML file of the custom app from /
+    """
+    exposed = True
+
+    indexHtml = None
+
+    vars = {
+        'apiRoot': '/api/v1',
+        'staticRoot': '/static',
+        'title': 'Hello World'
+    }
+
+    template = r"""
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <title>${title}</title>
+        <link rel="stylesheet"
+              href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
+        <link rel="stylesheet"
+              href="${staticRoot}/lib/bootstrap/css/bootstrap.min.css">
+        <link rel="stylesheet"
+              href="${staticRoot}/lib/fontello/css/fontello.css">
+        <link rel="stylesheet"
+              href="${staticRoot}/lib/fontello/css/animation.css">
+        <link rel="stylesheet"
+              href="${staticRoot}/built/app.min.css">
+        <link rel="stylesheet"
+              href="${staticRoot}/built/plugins/hello_app/hello_app.min.css">
+        <link rel="icon"
+              type="image/png"
+              href="${staticRoot}/img/Girder_Favicon.png">
+
+      </head>
+      <body>
+        <div id="g-global-info-apiroot" class="hide">${apiRoot}</div>
+        <div id="g-global-info-staticroot" class="hide">${staticRoot}</div>
+        <script src="${staticRoot}/built/libs.min.js"></script>
+        <script src="${staticRoot}/built/app.min.js"></script>
+        <script src="${staticRoot}/built/plugins/gravatar/plugin.min.js">
+        </script>
+        <script src="${staticRoot}/built/plugins/hello_app/hello_app.min.js">
+        </script>
+        <script src="${staticRoot}/built/plugins/hello_app/main.min.js"></script>
+      </body>
+    </html>
+    """
+
+    def GET(self):
+        if self.indexHtml is None:
+            self.indexHtml = mako.template.Template(self.template).render(
+                **self.vars)
+
+        return self.indexHtml
+
+
+def load(info):
+    # Bind our hello REST resource
+    info['apiRoot'].hello = Hello()
+
+    # Move girder app to /girder, serve our custom app from /
+    info['serverRoot'], info['serverRoot'].girder = (CustomAppRoot(),
+                                                     info['serverRoot'])
+    info['serverRoot'].api = info['serverRoot'].girder.api

--- a/hello_app/server/hello_rest.py
+++ b/hello_app/server/hello_rest.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from girder.api import access
+from girder.api.describe import Description
+from girder.api.rest import Resource
+
+
+class Hello(Resource):
+    def __init__(self):
+        self.resourceName = 'hello'
+        self.route('GET', (), self.getHello)
+
+    @access.public
+    def getHello(self, params):
+        return 'hello world!'
+    getHello.description = Description('Returns "hello world!"')

--- a/hello_app/web_external/js/app.js
+++ b/hello_app/web_external/js/app.js
@@ -1,0 +1,18 @@
+hello_app.App = girder.App.extend({
+
+    render: function() {
+        this.$el.html(hello_app.templates.layout());
+
+        new hello_app.views.LayoutHeaderView({
+            el: this.$('#c-app-header-container'),
+            parentView: this
+        }).render();
+
+        return this;
+    },
+
+    navigateTo: function (view, settings) {
+        this.$('#g-app-body-container').removeClass('c-body-nopad');
+        return girder.App.prototype.navigateTo.apply(this, arguments)
+    }
+});

--- a/hello_app/web_external/js/init.js
+++ b/hello_app/web_external/js/init.js
@@ -1,0 +1,11 @@
+var hello_app = hello_app || {};
+
+_.extend(hello_app, {
+    models: {},
+    collections: {},
+    views: {},
+    router: new Backbone.Router(),
+    events: _.clone(Backbone.Events)
+});
+
+girder.router.enabled(false);

--- a/hello_app/web_external/js/main.js
+++ b/hello_app/web_external/js/main.js
@@ -1,0 +1,8 @@
+$(function () {
+    hello_app.events.trigger('g:appload.before');
+    var app = new hello_app.App({
+        el: 'body',
+        parentView: null
+    });
+    hello_app.events.trigger('g:appload.after');
+});

--- a/hello_app/web_external/js/view.js
+++ b/hello_app/web_external/js/view.js
@@ -1,0 +1,1 @@
+hello_app.View = girder.View.extend({});

--- a/hello_app/web_external/js/views/layout/HeaderUserView.js
+++ b/hello_app/web_external/js/views/layout/HeaderUserView.js
@@ -1,0 +1,48 @@
+hello_app.views.LayoutHeaderUserView = hello_app.View.extend({
+
+
+    events: {
+        'click a.g-login':function(){
+            girder.events.trigger('g:loginUi');
+        },
+
+        'click a.g-register':function(){
+            girder.events.trigger('g:registerUi');
+        },
+
+        'click a.g-logout':function(){
+            girder.restRequest({
+                path:'user/authentication',
+                type:'DELETE'
+            }).done(_.bind(function(){
+                girder.currentUser=null;
+                girder.events.trigger('g:login');
+            },this));
+        },
+
+        'click a.g-my-settings':function(){
+            girder.router.navigate('useraccount/'+girder.currentUser.get('_id')+
+                                    '/info',{trigger:true});
+        }
+    },
+
+
+    initialize: function () {
+        girder.events.on('g:login', this.render, this);
+    },
+
+    render: function () {
+        this.$el.html(hello_app.templates.layoutHeaderUser({
+            user: girder.currentUser
+        }));
+
+        if (girder.currentUser) {
+            this.$('.h-portrait-wrapper').css(
+                'background-image', 'url(' +
+                girder.currentUser.getGravatarUrl(36) + ')');
+        }
+        return this;
+    }
+
+
+});

--- a/hello_app/web_external/js/views/layout/HeaderView.js
+++ b/hello_app/web_external/js/views/layout/HeaderView.js
@@ -1,0 +1,18 @@
+hello_app.views.LayoutHeaderView = hello_app.View.extend({
+    events: {
+    },
+
+    render: function () {
+        this.$el.html(hello_app.templates.layoutHeader());
+
+        this.$('a[title]').tooltip({
+            placement: 'bottom',
+            delay: {show: 300}
+        });
+
+        new hello_app.views.LayoutHeaderUserView({
+            el: this.$('.h-current-user-wrapper'),
+            parentView: this
+        }).render();
+    }
+});

--- a/hello_app/web_external/stylesheets/layout.styl
+++ b/hello_app/web_external/stylesheets/layout.styl
@@ -1,0 +1,77 @@
+@import 'nib'
+
+$headerHeight = 54px
+$portraitHeight = 38px
+
+.h-header-wrapper
+  height $headerHeight
+  padding-right 20px
+  padding-left 20px
+  background-color rgba(255, 255, 255, 0.88)
+  border-bottom 1px solid #e6e6e6
+  transition background-color 0.4s ease-in-out
+  position fixed
+  top 0
+  width 100%
+  z-index 10
+
+  &:hover
+    background-color white
+
+  .h-user-link
+    color #444
+    font-size 16px
+
+    &:hover
+      color #66a
+
+  .h-login-link-wrapper
+    font-size 16px
+
+  .h-user-link-wrapper
+    display inline-block
+
+  .h-portrait-wrapper
+    border-radius 50%
+    display inline-block
+    margin-right 10px
+    background-color #d6d6d6
+    height $portraitHeight
+    width $portraitHeight
+    background-size $portraitHeight $portraitHeight
+
+  .h-current-user-text > *
+    vertical-align middle
+    line-height $headerHeight
+
+  .h-current-user-wrapper
+    float right
+
+  .h-icons-wrapper
+    display inline
+    line-height $headerHeight
+    font-size 21px
+
+    &>a
+      color #444
+      margin-right 4px
+      border 1px solid transparent
+      border-radius 3px
+      padding 3px
+
+      &:hover
+        color #449
+        border 1px solid #e2e2e2
+        background linear-gradient(top, white 60%, #f6f6f6 100%)
+
+      &:active
+        background linear-gradient(bottom, white 60%, #f6f6f6 100%)
+
+#g-app-body-container
+  margin 0
+  margin-top $headerHeight
+  min-height 0
+  padding 12px 15px
+
+.h-body-nopad
+  padding 0 !important

--- a/hello_app/web_external/templates/layout.jade
+++ b/hello_app/web_external/templates/layout.jade
@@ -1,0 +1,8 @@
+#c-app-header-container
+#g-app-body-container
+#c-app-footer-container
+
+#g-app-progress-container
+
+#g-dialog-container.modal.fade
+#g-alerts-container

--- a/hello_app/web_external/templates/layout/layoutHeader.jade
+++ b/hello_app/web_external/templates/layout/layoutHeader.jade
@@ -1,0 +1,6 @@
+.h-header-wrapper
+  .h-icons-wrapper
+    a.h-home-link(title="Home", href="#")
+      i.icon-home
+  .h-current-user-wrapper
+  .g-clear-both

--- a/hello_app/web_external/templates/layout/layoutHeaderUser.jade
+++ b/hello_app/web_external/templates/layout/layoutHeaderUser.jade
@@ -1,0 +1,24 @@
+.h-current-user-text
+  if (user)
+    .h-portrait-wrapper
+    .h-user-link-wrapper
+      a.h-user-link(data-toggle="dropdown", data-target="#g-user-action-menu")
+        | #{user.get('firstName')} #{user.get('lastName')}
+        i.icon-down-open
+      #g-user-action-menu.dropdown
+        ul.dropdown-menu(role="menu")
+          li(role="presentation")
+            a.g-my-settings
+              i.icon-cog
+              | My account
+          li.divider(role="presentation")
+          li(role="presentation")
+            a.g-logout
+              i.icon-logout
+              | Log out
+  else
+    .h-login-link-wrapper
+      a.g-register Register
+      |  or
+      a.g-login  Log In
+        i.icon-login


### PR DESCRIPTION
This is a Girder plugin with the following features
- A custom application served out of "/" with the normal app served out of "/girder"
- A custom layout allowing users to log in and out
- Gravatar support
- Adds a demo REST resource specific to the plugin

@jeffbaumes to try this out, symlink the `hello_app` directory into the girder plugins directory. You'll need to run `grunt` from the girder directory to build it. Once you enable the plugin and restart the server, you should see the new application being served out of /.
