### PR TITLE
Stop image detail modal from going off screen

### DIFF
--- a/imagespace/web_external/js/views/widgets/ImageDetailWidget.js
+++ b/imagespace/web_external/js/views/widgets/ImageDetailWidget.js
@@ -35,6 +35,9 @@ imagespace.views.ImageDetailWidget = imagespace.View.extend({
                 // 20 is the padding of .modal-body and 30 is the margin of .modal-dialog
                 $('.modal-dialog').css('width', ($('.modal-body img').outerWidth() + 20 + 30) + 'px');
             }
+
+            $('.modal-inner-content').css('height', $('.modal-content').height() * 0.3);
+            $('.modal-inner-content').css('overflow', 'auto');
         });
 
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));

--- a/imagespace/web_external/templates/widgets/imageDetailWidget.jade
+++ b/imagespace/web_external/templates/widgets/imageDetailWidget.jade
@@ -3,77 +3,78 @@
 - var url = image.get('imageUrl')
 
 .modal-dialog
-    .modal-content
-        .modal-header
-            button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
-            h4.modal-title= title
-        .modal-body
-            a(href="#{url}", target="_blank")
-                img.im-image-detail.im-blur(src="#{url}")
-            if searches
-              .im-actions
-                | Search by
-                each val, key in searches
-                  a(href='#search/' + encodeURIComponent(url) + '/' + key, data-dismiss="modal").btn.btn-link.btn-default #{val.niceName}
-            if image.has('highlight')
-                h4 Match
-                dl.dl-horizontal
-                    for val, key in image.get('highlight')
-                        if system.indexOf(key) === -1 && hidden.indexOf(key) === -1
-                            dt
-                                b= key
-                            dd
-                                span !{val}
-            h4 Attributes
-            dl.dl-horizontal.im-attributes
-                for val, key in image.attributes
-                    if system.indexOf(key) === -1 && hidden.indexOf(key) === -1
-                        dt
-                            b= key
-                        dd.im-attribute
-                            if (val !== undefined && val !== null && typeof val[0] === 'string' && val[0].startsWith('http'))
-                                a(href=val[0], target='_blank')= val[0]
-                            else if (val !== undefined && val !== null && typeof val === 'string' && val.startsWith('http'))
-                                a(href=val, target='_blank')= val
-                            else
-                                span= val
-                            span.im-search-operations.hidden
-                                | &nbsp;-&nbsp;
-                                a.im-search-mod(im-search='#{key}:"#{val}"', title='Start new search for images matching this attribute')
-                                    | Search
-                                | &nbsp;-&nbsp;
-                                a.im-search-mod(im-search='#{query} AND #{key}:"#{val}"', title='Narrow search to images matching this attribute')
-                                    | Sub-search
-                                if key == 'camera_serial_number'
-                                    | &nbsp;-&nbsp;
-                                    a(href='#{stolenCameraPrefix}?serial=#{val}&searchType=MANUAL', target='_blank')
-                                        | Search stolencamerafinder.com
-            h4
-                a(data-toggle="collapse", href="#im-system-attributes") System Attributes
-            .collapse#im-system-attributes
-                dl.dl-horizontal.im-attributes
-                    for key in system
-                        - var val = image.get(key)
-                        dt
-                            b= key
-                        dd.im-attribute
-                            if (val !== undefined && val !== null && typeof val[0] === 'string' && val[0].startsWith('http'))
-                                a(href=val[0], target='_blank')= val[0]
-                            else if (val !== undefined && val !== null && typeof val === 'string' && val.startsWith('http'))
-                                a(href=val, target='_blank')= val
-                            else
-                                span= val
-                            span.im-search-operations.hidden
-                                | &nbsp;-&nbsp;
-                                a.im-search-mod(im-search='#{key}:"#{val}"', title='Start new search for images matching this attribute')
-                                    | Search
-                                | &nbsp;-&nbsp;
-                                a.im-search-mod(im-search='#{query} AND #{key}:"#{val}"', title='Narrow search to images matching this attribute')
-                                    | Sub-search
-                                if key == 'camera_serial_number'
-                                    | &nbsp;-&nbsp;
-                                    a(href='#{stolenCameraPrefix}?serial=#{val}&searchType=MANUAL', target='_blank')
-                                        | Search stolencamerafinder.com
-        .modal-footer
-            a.btn.btn-small.btn-default(data-dismiss="modal")
-                | Close
+  .modal-content
+    .modal-header
+      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      h4.modal-title= title
+    .modal-body
+      a(href="#{url}", target="_blank")
+        img.im-image-detail.im-blur(src="#{url}")
+      if searches
+        .im-actions
+        | Search by
+        each val, key in searches
+          a(href='#search/' + encodeURIComponent(url) + '/' + key, data-dismiss="modal").btn.btn-link.btn-default #{val.niceName}
+      .modal-inner-content
+        if image.has('highlight')
+          h4 Match
+          dl.dl-horizontal
+            for val, key in image.get('highlight')
+              if system.indexOf(key) === -1 && hidden.indexOf(key) === -1
+                dt
+                  b= key
+                dd
+                  span !{val}
+        h4 Attributes
+        dl.dl-horizontal.im-attributes
+          for val, key in image.attributes
+            if system.indexOf(key) === -1 && hidden.indexOf(key) === -1
+              dt
+                b= key
+              dd.im-attribute
+                if (val !== undefined && val !== null && typeof val[0] === 'string' && val[0].startsWith('http'))
+                  a(href=val[0], target='_blank')= val[0]
+                else if (val !== undefined && val !== null && typeof val === 'string' && val.startsWith('http'))
+                  a(href=val, target='_blank')= val
+                else
+                  span= val
+                span.im-search-operations.hidden
+                  | &nbsp;-&nbsp;
+                  a.im-search-mod(im-search='#{key}:"#{val}"', title='Start new search for images matching this attribute')
+                    | Search
+                  | &nbsp;-&nbsp;
+                  a.im-search-mod(im-search='#{query} AND #{key}:"#{val}"', title='Narrow search to images matching this attribute')
+                    | Sub-search
+                  if key == 'camera_serial_number'
+                    | &nbsp;-&nbsp;
+                    a(href='#{stolenCameraPrefix}?serial=#{val}&searchType=MANUAL', target='_blank')
+                      | Search stolencamerafinder.com
+        h4
+          a(data-toggle="collapse", href="#im-system-attributes") System Attributes
+        .collapse#im-system-attributes
+          dl.dl-horizontal.im-attributes
+            for key in system
+              - var val = image.get(key)
+              dt
+                b= key
+              dd.im-attribute
+                if (val !== undefined && val !== null && typeof val[0] === 'string' && val[0].startsWith('http'))
+                  a(href=val[0], target='_blank')= val[0]
+                else if (val !== undefined && val !== null && typeof val === 'string' && val.startsWith('http'))
+                  a(href=val, target='_blank')= val
+                else
+                  span= val
+                span.im-search-operations.hidden
+                  | &nbsp;-&nbsp;
+                  a.im-search-mod(im-search='#{key}:"#{val}"', title='Start new search for images matching this attribute')
+                    | Search
+                  | &nbsp;-&nbsp;
+                  a.im-search-mod(im-search='#{query} AND #{key}:"#{val}"', title='Narrow search to images matching this attribute')
+                    | Sub-search
+                  if key == 'camera_serial_number'
+                    | &nbsp;-&nbsp;
+                    a(href='#{stolenCameraPrefix}?serial=#{val}&searchType=MANUAL', target='_blank')
+                      | Search stolencamerafinder.com
+    .modal-footer
+      a.btn.btn-small.btn-default(data-dismiss="modal")
+        | Close


### PR DESCRIPTION
Fixes #72 

Changed indentation, the diff that ignores whitespace changes is [here](https://github.com/memex-explorer/image_space/compare/fix-modal-overrun-72?w=1).

Before/After
![imagespace-72-before](https://cloud.githubusercontent.com/assets/608229/11979382/e690115e-a960-11e5-9aca-8d8b2f1d4dae.png)
![imagespace-72-after](https://cloud.githubusercontent.com/assets/608229/11979383/e804e762-a960-11e5-9030-3518a001c28b.png)
