### PR TITLE
Let certain collections disable pagination

### DIFF
--- a/imagespace/web_external/js/collections/SearchResultCollection.js
+++ b/imagespace/web_external/js/collections/SearchResultCollection.js
@@ -1,7 +1,7 @@
 imagespace.collections.SearchResultCollection = girder.Collection.extend({
-    pageLimit: 20,
     altUrl: 'imagesearch',
-
+    pageLimit: 20,
+    supportsPagination: true,
     model: imagespace.models.SearchResultModel,
 
     initialize: function (models, options) {

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -29,10 +29,12 @@ imagespace.views.SearchView = imagespace.View.extend({
             collection: this.collection
         }));
 
-        this.paginateWidget = new girder.views.PaginateWidget({
-            collection: this.collection,
-            parentView: this
-        });
+        if (this.collection.supportsPagination) {
+            this.paginateWidget = new girder.views.PaginateWidget({
+                collection: this.collection,
+                parentView: this
+            });
+        }
 
         this.collection.each(function (image) {
             var imageView = new imagespace.views.ImageView({
@@ -45,7 +47,10 @@ imagespace.views.SearchView = imagespace.View.extend({
         }, this);
 
         $('.alert-info').addClass('hidden');
-        this.paginateWidget.setElement(this.$('.im-pagination-container')).render();
+
+        if (this.collection.supportsPagination) {
+            this.paginateWidget.setElement(this.$('.im-pagination-container')).render();
+        }
 
         return this;
     }

--- a/imagespace/web_external/templates/body/search.jade
+++ b/imagespace/web_external/templates/body/search.jade
@@ -4,7 +4,7 @@
 
 .container-fluid
   .clearfix
-    if collection.length
+    if collection.supportsPagination && collection.length
       .im-results-pagination.pull-left
         .im-pagination-container
         p Showing results #{startIndex + 1} - #{toIndex} of #{total}


### PR DESCRIPTION
Certain image services support pagination while others don't (Flann does, CMU doesn't, etc). 

This allows each individual service to specify (in their collection) whether or not they support it, and as a result pagination is conditionally present.
