### PR TITLE
Update CMU plugin for case sensitivity

### DIFF
--- a/imagespace/server/__init__.py
+++ b/imagespace/server/__init__.py
@@ -19,6 +19,7 @@
 
 import mako
 import os
+import requests
 import subprocess
 from girder import constants
 from girder.constants import SettingKey
@@ -161,3 +162,32 @@ def load(info):
     info['serverRoot'], info['serverRoot'].girder = (CustomAppRoot(),
                                                      info['serverRoot'])
     info['serverRoot'].api = info['serverRoot'].girder.api
+
+
+def solr_documents_from_paths(paths):
+    """Given a list of paths, return list of relevant solr documents
+    by uppercasing the basename of the paths.
+
+    This performs several requests, each of size CHUNK_SIZE to avoid sending
+    too much data (HTTP 413).
+
+    :param paths: List of solr paths corresponding to the Solr id attribute
+    :returns: List of solr documents
+    """
+    CHUNK_SIZE = 20
+    documents = []
+
+    for i in xrange(0, len(paths), CHUNK_SIZE):
+        paths_chunk = paths[i:i + CHUNK_SIZE]
+
+        r = requests.get(os.environ['IMAGE_SPACE_SOLR'] + '/select', params={
+            'wt': 'json',
+            'q': 'mainType:image',
+            'fq': 'resourcename_t_md:(%s)' %
+            ' '.join('%s' % os.path.basename(p).upper() for p in paths_chunk),
+            'rows': str(CHUNK_SIZE)
+        }, verify=False)
+
+        documents += r.json()['response']['docs']
+
+    return documents

--- a/imagespace/server/imagesearch_rest.py
+++ b/imagespace/server/imagesearch_rest.py
@@ -20,7 +20,6 @@
 from girder.api import access
 from girder.api.describe import Description
 from girder.api.rest import Resource
-from girder import logger
 
 import requests
 import os

--- a/imagespace/server/imagesearch_rest.py
+++ b/imagespace/server/imagesearch_rest.py
@@ -39,10 +39,10 @@ class ImageSearch(Resource):
         return self._imageSearch(params)
 
     def _imageSearch(self, params):
-        def filenameLower(filename):
+        def filenameUpper(filename):
             path = filename.replace('file:', '')
             return 'file:%s' % os.path.join(os.path.dirname(path),
-                                            os.path.basename(path).lower())
+                                            os.path.basename(path).upper())
 
         limit = params['limit'] if 'limit' in params else '100'
         query = params['query'] if 'query' in params else '*'
@@ -66,7 +66,7 @@ class ImageSearch(Resource):
             image['highlight'] = result['highlighting'][image['id']]
 
         for doc in result['response']['docs']:
-            doc['id'] = filenameLower(doc['id'])
+            doc['id'] = filenameUpper(doc['id'])
 
         response = {
             'numFound': result['response']['numFound'],

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -18,7 +18,10 @@ imagespace.views.SearchView = imagespace.View.extend({
         this.$el = window.app.$('#g-app-body-container');
         this.collection = settings.collection;
         this.viewMode = localStorage.getItem('viewMode') || 'grid';
-        this.collection.on('g:changed', _.bind(this.render, this));
+        this.collection.on('g:changed', _.bind(function () {
+            this.render();
+            $('.alert-info').addClass('hidden');
+        }, this));
         this.collection.fetch(settings.collection.params || {}, true);
     },
 
@@ -69,7 +72,11 @@ imagespace.router.route('search/:query', 'search', function (query) {
 
 imagespace.router.route('search/:url/:mode', 'search', function (url, mode) {
     // Replace Girder token with current session's token if necessary
-    var parts = url.split('&token=');
+    var niceName = (_.has(imagespace.searches[mode], 'niceName')) ? imagespace.searches[mode].niceName : mode,
+        parts = url.split('&token=');
+
+    $('.alert-info').html('Performing ' + niceName  + ' search <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
+
     if (parts.length === 2) {
         url = parts[0] + '&token=' + girder.cookie.find('girderToken');
     }
@@ -88,12 +95,12 @@ imagespace.router.route('search/:url/:mode', 'search', function (url, mode) {
             mode: mode,
             image: image
         });
+        $('.alert-info').html('Performing ' + niceName  + ' search <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
 
         girder.events.trigger('g:navigateTo', imagespace.views.SearchView, {
             collection: imagespace.searches[mode].search(image)
         });
 
-        $('.alert-info').addClass('hidden');
         imagespace.userDataView.render();
 
         $('.modal-open').css('overflow', 'auto');

--- a/imagespace_cmu/server/__init__.py
+++ b/imagespace_cmu/server/__init__.py
@@ -23,7 +23,8 @@ from .cmu_search import CmuFullImageSearch, CmuImageBackgroundSearch
 
 def load(info):
     required_env_vars = ('IMAGE_SPACE_CMU_BACKGROUND_SEARCH',
-                         'IMAGE_SPACE_CMU_FULL_IMAGE_SEARCH')
+                         'IMAGE_SPACE_CMU_FULL_IMAGE_SEARCH',
+                         'IMAGE_SPACE_CMU_PREFIX')
 
     for required_var in required_env_vars:
         if required_var not in os.environ \

--- a/imagespace_cmu/web_client/js/init.js
+++ b/imagespace_cmu/web_client/js/init.js
@@ -8,7 +8,7 @@ girder.events.once('im:appload.after', function () {
                     },
                     supportsPagination: false,
                     comparator: function (image) {
-                        return -image.get('score');
+                        return -image.get('im_score');
                     }
                 }, collectionArgs || {}));
             }


### PR DESCRIPTION
@jeffbaumes This updates the CMU plugin with respects to upper-casing and not serving up the images from within the proxy, as such it passes along the proper solr documents in the python response.

It also adds a basic utility to the regular ImageSpace plugin for efficiently retrieving a group of solr documents from a list of ids.
