### PR TITLE
Refresh sidebar on login/logout events

### DIFF
--- a/imagespace/web_external/js/views/body/FrontPageView.js
+++ b/imagespace/web_external/js/views/body/FrontPageView.js
@@ -6,7 +6,6 @@ imagespace.views.FrontPageView = girder.views.FrontPageView.extend({
 
     render: function () {
         this.$el.html(imagespace.templates.frontPage());
-        imagespace.headerView.render();
 
         var searchBar = new imagespace.views.SearchBarView({
             el: this.$('#search-bar'),

--- a/imagespace/web_external/js/views/body/SearchBarView.js
+++ b/imagespace/web_external/js/views/body/SearchBarView.js
@@ -136,9 +136,6 @@ imagespace.views.SearchBarView = imagespace.View.extend({
                     image.imageUrl = dataURLReader.result;
                     image = new imagespace.models.UploadedImageModel(image);
 
-                    imagespace.userData.images.add(image, {
-                        at: 0
-                    });
                     if (girder.currentUser) {
                         girder.restRequest({
                             path: 'folder?text=Private'
@@ -166,7 +163,8 @@ imagespace.views.SearchBarView = imagespace.View.extend({
                                     image.set('item_id', fileObject.attributes.itemId);
                                     item._sendMetadata(image.attributes, _.bind(function () {
                                         this.render();
-                                        imagespace.userDataView.render();
+                                        // Re-fetch images from Girder which will re-render sidebar
+                                        imagespace.userDataView.updateUserData();
                                     }, this));
                                 }, this));
                             }

--- a/imagespace/web_external/js/views/layout/HeaderUserView.js
+++ b/imagespace/web_external/js/views/layout/HeaderUserView.js
@@ -9,22 +9,25 @@ imagespace.views.LayoutHeaderUserView = imagespace.View.extend({
             girder.events.trigger('g:registerUi');
         },
 
-        'click a.g-logout': function () {
-            girder.restRequest({
-                path: 'user/authentication',
-                type: 'DELETE'
-            }).done(_.bind(function () {
-                girder.currentUser = null;
-                girder.events.trigger('g:login');
-            }, this));
+        'click a.g-logout': girder.logout
+    },
+
+    redisplay: function () {
+        this.render();
+
+        if (imagespace.userDataView) {
+            imagespace.userDataView.updateUserData();
         }
     },
 
     initialize: function () {
-        girder.events.on('g:login', function () {
+        girder.events.on('g:login.success', this.redisplay, this);
+        girder.events.on('g:logout.success', function () {
             this.render();
-            if (imagespace.userDataView) {
-                imagespace.userDataView.render();
+
+            if (_.has(imagespace, 'userData') &&
+                _.has(imagespace.userData, 'images')) {
+                imagespace.userData.images.reset([]);
             }
         }, this);
     },

--- a/imagespace/web_external/js/views/layout/UserDataView.js
+++ b/imagespace/web_external/js/views/layout/UserDataView.js
@@ -16,9 +16,8 @@ imagespace.views.LayoutUserDataView = imagespace.View.extend({
      * Updates the data from a users private folders and adds
      * them to the userData.images collection.
      *
-     * This is a bit of a misnomer, because it only appends results. So
-     * running this after a user logs out won't alter the collection at all
-     * when in reality it should be emptied. @todo
+     * This needs to remain idempotent due to its use in render
+     * methods.
      **/
     updateUserData: function (done) {
         done = (_.isFunction(done) ? done : function () {});
@@ -37,17 +36,17 @@ imagespace.views.LayoutUserDataView = imagespace.View.extend({
                 girder.restRequest({
                     path: 'item?limit=100&offset=0&sort=created&sortdir=-1&folderId=' + privateFolder._id
                 }).done(_.bind(function (items) {
+                    var models = [];
+
                     items.forEach(_.bind(function (item) {
-                        var parts, imageModel;
+                        var parts;
                         if (item.meta && item.meta.item_id) {
                             // Determine if the image is solr backed or not
                             if (item.meta.id.indexOf(imagespace.solrPrefix) === 0) {
-                                imageModel = new imagespace.models.ImageModel(item.meta);
+                                models.push(new imagespace.models.ImageModel(item.meta));
                             } else {
-                                imageModel = new imagespace.models.UploadedImageModel(item.meta);
+                                models.push(new imagespace.models.UploadedImageModel(item.meta));
                             }
-
-                            imagespace.userData.images.add(imageModel);
 
                             // Replace Girder token with current session's token if necessary
                             parts = item.meta.imageUrl.split('&token=');
@@ -56,6 +55,9 @@ imagespace.views.LayoutUserDataView = imagespace.View.extend({
                             }
                         }
                     }, this));
+
+                    imagespace.userData.images.set(models);
+
                     done();
                 }, this));
             } else {

--- a/imagespace/web_external/js/views/layout/UserDataView.js
+++ b/imagespace/web_external/js/views/layout/UserDataView.js
@@ -12,6 +12,14 @@ imagespace.views.LayoutUserDataView = imagespace.View.extend({
         this.updateUserData();
     },
 
+    /**
+     * Updates the data from a users private folders and adds
+     * them to the userData.images collection.
+     *
+     * This is a bit of a misnomer, because it only appends results. So
+     * running this after a user logs out won't alter the collection at all
+     * when in reality it should be emptied. @todo
+     **/
     updateUserData: function (done) {
         done = (_.isFunction(done) ? done : function () {});
 


### PR DESCRIPTION
This properly readjusts the sidebar when a user logs in or out, rather
than requiring a refresh.

Some extra care was needed because updating user data won't reset the
collection, added comment/todo for it.

Fixes #121 
