### PR TITLE
Fix header thumbnail keyerror

### DIFF
--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -11,6 +11,10 @@ _.extend(imagespace, {
 
     events: _.clone(Backbone.Events),
 
+    /**
+     * imagespace.userData.images is a heterogeneous backbone
+     * collection consisting of ImageModels and UploadedImageModels.
+     **/
     userData: {
         images: []
     },

--- a/imagespace/web_external/js/views/layout/UserDataView.js
+++ b/imagespace/web_external/js/views/layout/UserDataView.js
@@ -30,9 +30,15 @@ imagespace.views.LayoutUserDataView = imagespace.View.extend({
                     path: 'item?limit=100&offset=0&sort=created&sortdir=-1&folderId=' + privateFolder._id
                 }).done(_.bind(function (items) {
                     items.forEach(_.bind(function (item) {
-                        var parts;
+                        var parts, imageModel;
                         if (item.meta && item.meta.item_id) {
-                            var imageModel = new imagespace.models.UploadedImageModel(item.meta);
+                            // Determine if the image is solr backed or not
+                            if (item.meta.id.indexOf(imagespace.solrPrefix) === 0) {
+                                imageModel = new imagespace.models.ImageModel(item.meta);
+                            } else {
+                                imageModel = new imagespace.models.UploadedImageModel(item.meta);
+                            }
+
                             imagespace.userData.images.add(imageModel);
 
                             // Replace Girder token with current session's token if necessary

--- a/imagespace/web_external/js/views/widgets/ImageDetailWidget.js
+++ b/imagespace/web_external/js/views/widgets/ImageDetailWidget.js
@@ -65,7 +65,8 @@ imagespace.views.ImageDetailWidget = imagespace.View.extend({
     },
 
     render: function () {
-        if (this.image.has('relevantAds')) {
+        // If ads have already been retrieved, or it's an uploaded image with no relevant ads, render
+        if (this.image.has('relevantAds') || this.image instanceof imagespace.models.UploadedImageModel) {
             return this._render();
         } else {
             girder.restRequest({


### PR DESCRIPTION
@jeffbaumes 
This was occasionally breaking because images in the left sidebar are
either uploaded or saved from an existing Solr image. Existing Solr
images have an id that can be translated to a URL to search Solr for
relevant ads, while uploaded images don't.

The long and short of it is, an image saved from Solr will show relevant
ads when rendered, and uploaded images won't.
