### PR TITLE
Remove old search views before new ones are created

### DIFF
--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -93,6 +93,10 @@ imagespace.router.route('search/:query(/params/:params)', 'search', function (qu
     imagespace.headerView.render({query: query});
     $('.alert-info').html('Searching <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
 
+    if (_.has(imagespace, 'searchView')) {
+        imagespace.searchView.destroy();
+    }
+
     imagespace.searchView = new imagespace.views.SearchView({
         collection: imagespace.getImageCollectionFromQuery(query),
         parentView: window.app


### PR DESCRIPTION
This solves a bug that resulted in occasional flashing of the wrong
results before rendering the proper results. It comes down to event
listening on things that shouldn't still be in memory but
are. Destroying the old search views before creating new ones resolves that.

@jeffbaumes I believe this solves the issue the SUG mentioned.
