### PR TITLE
Add note of supported file types

### DIFF
--- a/imagespace/web_external/templates/body/help.jade
+++ b/imagespace/web_external/templates/body/help.jade
@@ -17,6 +17,10 @@
 
         h4 Starting with an image
         p.
+           Note: For a complete set of supported image types see Tika's page on <a href="http://tika.apache.org/1.11/formats.html#Image_formats">supported document formats</a>. While
+           those images can be analysed, only the following are officially supported via ImageSpace: JPEG, GIF, PNG, SVG, and BMP.
+           Certain searches may only support a subset of such image types, for example SMQTK supports PNG, JPEG, and TIFF images.
+        p.
             First, ensure you are logged in, or register for an account.
         p.
             Use the "Browse or drop image" button to the left to drag-and-drop an


### PR DESCRIPTION
Fixes #42

The list was achieved by intersecting supported Tika formats with what is renderable via the img tag.
