### PR TITLE
IQR Integration

### DIFF
--- a/imagespace/server/__init__.py
+++ b/imagespace/server/__init__.py
@@ -109,16 +109,16 @@ class CustomAppRoot(object):
         <script src="${staticRoot}/built/app.min.js"></script>
         <script src="${staticRoot}/built/plugins/gravatar/plugin.min.js">
         </script>
-        % for plugin in pluginJs:
-           % if plugin != 'imagespace':
-        <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
-           % endif
-        % endfor
         <script src="${staticRoot}/built/plugins/imagespace/imagespace-libs.min.js">
         </script>
         <script src="${staticRoot}/built/plugins/imagespace/imagespace.min.js">
         </script>
         <script src="${staticRoot}/built/plugins/imagespace/main.min.js"></script>
+         % for plugin in pluginJs:
+           % if plugin != 'imagespace':
+        <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
+           % endif
+        % endfor
       </body>
     </html>
     """

--- a/imagespace/web_external/js/collections/ImageCollection.js
+++ b/imagespace/web_external/js/collections/ImageCollection.js
@@ -88,7 +88,8 @@ imagespace.collections.ImageCollection = girder.Collection.extend({
             if (list.length > this.pageLimit) {
                 // This means we have more pages to display still. Pop off
                 // the extra that we fetched.
-                list.pop();
+                // @todo This is silently removing extra results (from shas mapping to dup documents)
+                list = _.first(list, this.pageLimit);
                 this._hasMorePages = true;
             } else {
                 this._hasMorePages = false;

--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -199,7 +199,7 @@ _.extend(imagespace, {
      * in the URL query string and navigates there using the imagespace router.
      * Routes aren't triggered, it is a silent navigation.
      **/
-    updateQueryParams: function (params, skipHistory) {
+    updateQueryParams: function (params, navigateArgs) {
         var hash = Backbone.history.getHash(),
             paramsStartIndex = hash.indexOf('/params/'),
             qs = (paramsStartIndex !== -1) ?
@@ -211,9 +211,8 @@ _.extend(imagespace, {
 
         _.extend(qsObj, params);
 
-        imagespace.router.navigate(hashBeforeParams + '/params/' + imagespace.createQueryString(qsObj), {
-            replace: replace
-        });
+        imagespace.router.navigate(hashBeforeParams + '/params/' + imagespace.createQueryString(qsObj),
+                                   navigateArgs || {});
     },
 
     oppositeCaseFilename: function (filename) {

--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -215,6 +215,25 @@ _.extend(imagespace, {
                                    navigateArgs || {});
     },
 
+    // Forcibly set what the query parameters should be, this allows
+    // the user to remove a specific query parameter using parseQueryString and _.omit
+    setQueryParams: function (params, navigateArgs) {
+        var hash = Backbone.history.getHash(),
+            paramsStartIndex = hash.indexOf('/params/'),
+            qs = (paramsStartIndex !== -1) ?
+                  hash.substr(paramsStartIndex).replace('/params/', '') : '',
+            qsObj = imagespace.parseQueryString(qs),
+            hashBeforeParams = (paramsStartIndex !== -1) ?
+                                hash.substr(0, paramsStartIndex) : hash;
+
+        if (_.size(params)) {
+            imagespace.router.navigate(hashBeforeParams, navigateArgs || {});
+        } else {
+            imagespace.router.navigate(hashBeforeParams + '/params/' + imagespace.createQueryString(params),
+                                       navigateArgs || {});
+        }
+    },
+
     oppositeCaseFilename: function (filename) {
         var parts = filename.split('/');
 

--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -147,6 +147,19 @@ _.extend(imagespace, {
         return imagespace.solrPrefix + file;
     },
 
+    /**
+     * Returns the query type (search, refine) with any arguments it
+     * takes (these are before the params).
+     * Example: /search/shotgun/params/page=1 returns [search, 'shotgun']
+     **/
+    getQueryTypeWithArguments: function (onlyArgs) {
+        var hash = Backbone.history.getHash()
+            .replace('/params/' + imagespace.getQueryParams(), ''),
+            values = hash.split('/');
+
+        return (onlyArgs) ? _.tail(values) : values;
+    },
+
     // Returns empty string if no params in the query string
     getQueryParams: function () {
         var hash = Backbone.history.getHash(),

--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -206,8 +206,7 @@ _.extend(imagespace, {
                   hash.substr(paramsStartIndex).replace('/params/', '') : '',
             qsObj = imagespace.parseQueryString(qs),
             hashBeforeParams = (paramsStartIndex !== -1) ?
-                                hash.substr(0, paramsStartIndex) : hash,
-            replace = !!skipHistory;
+                                hash.substr(0, paramsStartIndex) : hash;
 
         _.extend(qsObj, params);
 

--- a/imagespace/web_external/js/views/body/FrontPageView.js
+++ b/imagespace/web_external/js/views/body/FrontPageView.js
@@ -1,6 +1,5 @@
 imagespace.views.FrontPageView = girder.views.FrontPageView.extend({
     initialize: function () {
-        girder.cancelRestRequests('fetch');
         this.render();
     },
 

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -150,8 +150,12 @@ imagespace.router.route('search/:url/:mode(/params/:params)', 'search', function
         });
         $('.alert-info').html('Performing ' + niceName  + ' search <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
 
+        if (_.has(imagespace, 'searchView')) {
+            imagespace.searchView.destroy();
+        }
+
         var coll = imagespace.searches[mode].search(image);
-        girder.events.trigger('g:navigateTo', imagespace.views.SearchView, {
+        imagespace.searchView = new imagespace.views.SearchView({
             collection: coll,
             searchImage: image,
             url: url,

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -53,6 +53,13 @@ imagespace.views.SearchView = imagespace.View.extend({
     },
 
     render: function () {
+        // This is really hacky - but otherwise we are orphaning
+        // collection.pageLimit + 1 views each re-render (every time a page changes,
+        // classifications, etc)
+        _.each(this._childViews, function (child) {
+            child.destroy();
+        });
+
         this.$el.html(imagespace.templates.search({
             image: this.searchImage,
             mode: this.mode,
@@ -87,8 +94,17 @@ imagespace.views.SearchView = imagespace.View.extend({
         }
 
         return this;
-    }
+    },
 
+    /**
+     * Child views on this collection are the pagination widget (conditionally) and
+     * the image views. To retrieve the i'th image child view, just return the i'th element
+     * and potentially add 1 if the pagination view was the first one created.
+     **/
+    getChildImageView: function (i) {
+        var offset = (Number(this.collection.supportsPagination)) + i
+        return this._childViews[offset];
+    }
 });
 
 imagespace.router.route('search/:query(/params/:params)', 'search', function (query, params) {

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -29,7 +29,6 @@ imagespace.views.SearchView = imagespace.View.extend({
     },
 
     initialize: function (settings) {
-        girder.cancelRestRequests('fetch');
         this.$el = window.app.$('#g-app-body-container');
         this.collection = settings.collection;
         this.searchImage = settings.searchImage || false;

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -50,7 +50,6 @@ imagespace.views.SearchView = imagespace.View.extend({
 
             $('.alert-info').addClass('hidden');
         }, this));
-        this.collection.fetch(this.collection.params || {});
     },
 
     render: function () {
@@ -100,10 +99,12 @@ imagespace.router.route('search/:query(/params/:params)', 'search', function (qu
         imagespace.searchView.destroy();
     }
 
+    var coll = imagespace.getImageCollectionFromQuery(query);
     imagespace.searchView = new imagespace.views.SearchView({
-        collection: imagespace.getImageCollectionFromQuery(query),
+        collection: coll,
         parentView: window.app
     });
+    coll.fetch(coll.params || {});
 });
 
 imagespace.router.route('search/:url/:mode(/params/:params)', 'search', function (url, mode, params) {

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -150,12 +150,14 @@ imagespace.router.route('search/:url/:mode(/params/:params)', 'search', function
         });
         $('.alert-info').html('Performing ' + niceName  + ' search <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
 
+        var coll = imagespace.searches[mode].search(image);
         girder.events.trigger('g:navigateTo', imagespace.views.SearchView, {
-            collection: imagespace.searches[mode].search(image),
+            collection: coll,
             searchImage: image,
             url: url,
             mode: mode
         });
+        coll.fetch(coll.params || {});
 
         imagespace.userDataView.render();
 

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -45,7 +45,7 @@ imagespace.views.SearchView = imagespace.View.extend({
                  **/
                 imagespace.updateQueryParams({
                     page: this.collection.pageNum() + 1
-                }, this.collection.pageNum() == 0);
+                }, { replace: this.collection.pageNum() == 0 });
             }
 
             $('.alert-info').addClass('hidden');

--- a/imagespace/web_external/js/views/layout/UserDataView.js
+++ b/imagespace/web_external/js/views/layout/UserDataView.js
@@ -1,6 +1,5 @@
 imagespace.views.LayoutUserDataView = imagespace.View.extend({
     initialize: function (settings) {
-        girder.cancelRestRequests('fetch');
         imagespace.userData.images = new imagespace.collections.ImageCollection(null, {
             model: imagespace.models.UploadedImageModel,
             filterByQueryString: false

--- a/imagespace_smqtk/README.md
+++ b/imagespace_smqtk/README.md
@@ -9,3 +9,5 @@ Installation of this plugin is the same as any other, documented in the [install
 ## Environment Variables
 
 `IMAGE_SPACE_SMQTK_SIMILARITY_SEARCH` points to the SMQTK nearest neighbors service as a URL in the form http://somehost.com/nn.
+
+`IMAGE_SPACE_SMQTK_IQR_URL` points to the IQR service provided by SMQTK, this is a url in the form http://somehost.com.

--- a/imagespace_smqtk/server/__init__.py
+++ b/imagespace_smqtk/server/__init__.py
@@ -17,12 +17,26 @@
 #  limitations under the License.
 ###############################################################################
 import os
-
+from girder import events
 from .smqtk_search import SmqtkSimilaritySearch
+from .smqtk_iqr import SmqtkIqr
+
+
+def adjust_qparams_for_subtype(event):
+    """
+    SMQTK only works on png/jpeg/tiff as of now, so limit the results
+    to those to avoid confusion when using IQR.
+    """
+    if 'fq' not in event.info:
+        event.info['fq'] = []
+
+    event.info['fq'].append('subType:("png" OR "jpeg" OR "tiff")')
+    event.addResponse(event.info)
 
 
 def load(info):
-    required_env_vars = ('IMAGE_SPACE_SMQTK_SIMILARITY_SEARCH',)
+    required_env_vars = ('IMAGE_SPACE_SMQTK_SIMILARITY_SEARCH',
+                         'IMAGE_SPACE_SMQTK_IQR_URL',)
 
     for required_var in required_env_vars:
         if required_var not in os.environ \
@@ -34,3 +48,8 @@ def load(info):
             os.environ[required_var] = os.environ[required_var].rstrip('/')
 
     info['apiRoot'].smqtk_similaritysearch = SmqtkSimilaritySearch()
+    info['apiRoot'].smqtk_iqr = SmqtkIqr()
+
+    events.bind('imagespace.imagesearch.qparams',
+                'adjust_qparams_for_subtype',
+                adjust_qparams_for_subtype)

--- a/imagespace_smqtk/server/smqtk_iqr.py
+++ b/imagespace_smqtk/server/smqtk_iqr.py
@@ -25,6 +25,7 @@ from girder.utility.model_importer import ModelImporter
 from girder.api.rest import getBodyJson, getCurrentUser
 
 from girder.plugins.imagespace import solr_documents_from_field
+from girder import logger
 
 from .utils import getCreateSessionsFolder
 
@@ -103,6 +104,9 @@ class SmqtkIqr(Resource):
         # returned by IQR, sort the documents to match the confidence values.
         # Sort by confidence values first, then sha checksums second so duplicate images are grouped together
         confidenceValues = dict(resp['results'])  # Mapping of sha -> confidence values
+
+        if len(documents) < len(resp['results']):
+            logger.error('SID %s: There are SMQTK descriptors that have no corresponding Solr document(s).' % params['sid'])
 
         for document in documents:
             document['smqtk_iqr_confidence'] = confidenceValues[document['sha1sum_s_md']]

--- a/imagespace_smqtk/server/smqtk_iqr.py
+++ b/imagespace_smqtk/server/smqtk_iqr.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from girder.api import access
+from girder.api.describe import Description, describeRoute
+from girder.api.rest import Resource
+
+from girder.utility.model_importer import ModelImporter
+from girder.api.rest import getBodyJson, getCurrentUser
+
+from girder.plugins.imagespace import solr_documents_from_field
+
+from .utils import getCreateSessionsFolder
+
+import json
+import requests
+import os
+
+
+class SmqtkIqr(Resource):
+    def __init__(self):
+        self.search_url = os.environ['IMAGE_SPACE_SMQTK_IQR_URL']
+        self.resourceName = 'smqtk_iqr'
+        self.route('POST', ('session',), self.createSession)
+        self.route('GET', ('session',), self.getSessions)
+        self.route('PUT', ('refine',), self.refine)
+        self.route('GET', ('results',), self.results)
+
+    @access.user
+    @describeRoute(
+        Description('Get all session items')
+    )
+    def getSessions(self, params):
+        sessionsFolder = getCreateSessionsFolder()
+        return list(ModelImporter.model('folder').childItems(folder=sessionsFolder))
+
+    @access.user
+    @describeRoute(
+        Description('Create an IQR session, return the Girder Item representing that session')
+    )
+    def createSession(self, params):
+        sessionsFolder = getCreateSessionsFolder()
+        sessionId = requests.post(self.search_url + '/session').json()['sid']
+        return ModelImporter.model('item').createItem(name=sessionId,
+                                                      creator=getCurrentUser(),
+                                                      folder=sessionsFolder)
+        # create sessions folder in private directory if not existing
+        # post to init_session, get sid back
+        # create item named sid in sessions folder
+
+    @access.user
+    @describeRoute(
+        Description('Refine results based on positive and negative uuids')
+        .param('body', 'A JSON object containing the sid and pos_uuids and neg_uuids.',
+               paramType='body')
+    )
+    def refine(self, params):
+        params = getBodyJson()
+        r = requests.put(self.search_url + '/refine', data={
+            'sid': params['sid'],
+            'pos_uuids': json.dumps(params['pos_uuids']),
+            'neg_uuids': json.dumps(params['neg_uuids'])
+        })
+
+        return r.json()
+
+    @access.user
+    @describeRoute(
+        Description('Get the results of an IQR session')
+        .param('sid', 'ID of the IQR session')
+        .param('offset', 'Where to start from')
+        .param('limit', 'How many records to pull')
+    )
+    def results(self, params):
+        offset = int(params['offset'] if 'offset' in params else 0)
+        limit = int(params['limit'] if 'limit' in params else 20)
+
+        resp = requests.get(self.search_url + '/get_results', params={
+            'sid': params['sid'],
+            'i': offset,
+            'j': offset + limit
+        }).json() # @todo handle errors
+
+        documents = solr_documents_from_field('sha1sum_s_md', [sha for (sha, _) in resp['results']])
+
+        # The documents from Solr (since shas map to >= 1 document) may not be in the order of confidence
+        # returned by IQR, sort the documents to match the confidence values.
+        # Sort by confidence values first, then sha checksums second so duplicate images are grouped together
+        confidenceValues = dict(resp['results'])  # Mapping of sha -> confidence values
+
+        for document in documents:
+            document['smqtk_iqr_confidence'] = confidenceValues[document['sha1sum_s_md']]
+
+        return {
+            'numFound': resp['total_results'],
+            'docs': sorted(documents,
+                           key=lambda x: (x['smqtk_iqr_confidence'],
+                                          x['sha1sum_s_md']),
+                           reverse=True)
+        }

--- a/imagespace_smqtk/server/utils.py
+++ b/imagespace_smqtk/server/utils.py
@@ -1,0 +1,16 @@
+from girder.utility.model_importer import ModelImporter
+from girder.api.rest import getCurrentUser
+
+def getCreateSessionsFolder():
+    user = getCurrentUser()
+    folder = ModelImporter.model('folder')
+
+    # @todo Assumes a Private folder will always exist/be accessible
+    privateFolder = list(folder.childFolders(parentType='user',
+                                             parent=user,
+                                             user=user,
+                                             filters={
+                                                 'name': 'Private'
+                                             }))[0]
+
+    return folder.createFolder(privateFolder, 'iqr_sessions', reuseExisting=True)

--- a/imagespace_smqtk/web_client/js/AnnotationWidgetView.js
+++ b/imagespace_smqtk/web_client/js/AnnotationWidgetView.js
@@ -5,9 +5,9 @@ imagespace.views.AnnotationWidgetView = imagespace.View.extend({
                 done = _.bind(this.render, this);
 
             if (button.hasClass('smqtk-iqr-positive')) {
-                imagespace.smqtk.iqr.currentIqrSession().addPositiveUuid(this.image.get('sha1sum_s_md'), done);
+                imagespace.smqtk.iqr.currentIqrSession.addPositiveUuid(this.image.get('sha1sum_s_md'), done);
             } else if (button.hasClass('smqtk-iqr-negative')) {
-                imagespace.smqtk.iqr.currentIqrSession().addNegativeUuid(this.image.get('sha1sum_s_md'), done);
+                imagespace.smqtk.iqr.currentIqrSession.addNegativeUuid(this.image.get('sha1sum_s_md'), done);
             }
         },
     },
@@ -17,7 +17,7 @@ imagespace.views.AnnotationWidgetView = imagespace.View.extend({
     },
 
     render: function () {
-        var session = imagespace.smqtk.iqr.currentIqrSession(),
+        var session = imagespace.smqtk.iqr.currentIqrSession,
             positive = _.contains(session.get('meta').pos_uuids, this.image.get('sha1sum_s_md')),
             negative = _.contains(session.get('meta').neg_uuids, this.image.get('sha1sum_s_md'));
 

--- a/imagespace_smqtk/web_client/js/AnnotationWidgetView.js
+++ b/imagespace_smqtk/web_client/js/AnnotationWidgetView.js
@@ -1,29 +1,45 @@
 imagespace.views.AnnotationWidgetView = imagespace.View.extend({
+    tagName: 'div',
+    className: 'smqtk-iqr-annotation',
     events: {
-        'click .smqtk-iqr-annotation button': function (e) {
+        'click .smqtk-iqr-annotate': function (e) {
             var button = $(e.currentTarget),
                 done = _.bind(this.render, this);
 
             if (button.hasClass('smqtk-iqr-positive')) {
-                imagespace.smqtk.iqr.currentIqrSession.addPositiveUuid(this.image.get('sha1sum_s_md'), done);
+                if (this.isIqrPositive()) {
+                    imagespace.smqtk.iqr.currentIqrSession.removePositiveUuid(this.image.get('sha1sum_s_md'), done);
+                } else {
+                    imagespace.smqtk.iqr.currentIqrSession.addPositiveUuid(this.image.get('sha1sum_s_md'), done);
+                }
             } else if (button.hasClass('smqtk-iqr-negative')) {
-                imagespace.smqtk.iqr.currentIqrSession.addNegativeUuid(this.image.get('sha1sum_s_md'), done);
+                if (this.isIqrNegative()) {
+                    imagespace.smqtk.iqr.currentIqrSession.removeNegativeUuid(this.image.get('sha1sum_s_md'), done);
+                } else {
+                    imagespace.smqtk.iqr.currentIqrSession.addNegativeUuid(this.image.get('sha1sum_s_md'), done);
+                }
             }
-        },
+        }
     },
 
     initialize: function (settings) {
         this.image = settings.parentView.model;
     },
 
-    render: function () {
-        var session = imagespace.smqtk.iqr.currentIqrSession,
-            positive = _.contains(session.get('meta').pos_uuids, this.image.get('sha1sum_s_md')),
-            negative = _.contains(session.get('meta').neg_uuids, this.image.get('sha1sum_s_md'));
+    isIqrPositive: function () {
+        return (imagespace.smqtk.iqr.currentIqrSession.has('meta') &&
+                _.contains(imagespace.smqtk.iqr.currentIqrSession.get('meta').pos_uuids, this.image.get('sha1sum_s_md')));
+    },
 
+    isIqrNegative: function () {
+        return (imagespace.smqtk.iqr.currentIqrSession.has('meta') &&
+                _.contains(imagespace.smqtk.iqr.currentIqrSession.get('meta').neg_uuids, this.image.get('sha1sum_s_md')));
+    },
+
+    render: function () {
         this.$el.html(girder.templates.iqrAnnotationWidget({
-            positive: positive,
-            negative: negative
+            positive: this.isIqrPositive(),
+            negative: this.isIqrNegative()
         }));
         return this;
     }

--- a/imagespace_smqtk/web_client/js/AnnotationWidgetView.js
+++ b/imagespace_smqtk/web_client/js/AnnotationWidgetView.js
@@ -1,0 +1,30 @@
+imagespace.views.AnnotationWidgetView = imagespace.View.extend({
+    events: {
+        'click .smqtk-iqr-annotation button': function (e) {
+            var button = $(e.currentTarget),
+                done = _.bind(this.render, this);
+
+            if (button.hasClass('smqtk-iqr-positive')) {
+                imagespace.smqtk.iqr.currentIqrSession().addPositiveUuid(this.image.get('sha1sum_s_md'), done);
+            } else if (button.hasClass('smqtk-iqr-negative')) {
+                imagespace.smqtk.iqr.currentIqrSession().addNegativeUuid(this.image.get('sha1sum_s_md'), done);
+            }
+        },
+    },
+
+    initialize: function (settings) {
+        this.image = settings.parentView.model;
+    },
+
+    render: function () {
+        var session = imagespace.smqtk.iqr.currentIqrSession(),
+            positive = _.contains(session.get('meta').pos_uuids, this.image.get('sha1sum_s_md')),
+            negative = _.contains(session.get('meta').neg_uuids, this.image.get('sha1sum_s_md'));
+
+        this.$el.html(girder.templates.iqrAnnotationWidget({
+            positive: positive,
+            negative: negative
+        }));
+        return this;
+    }
+});

--- a/imagespace_smqtk/web_client/js/IqrImageCollection.js
+++ b/imagespace_smqtk/web_client/js/IqrImageCollection.js
@@ -1,0 +1,3 @@
+imagespace.collections.IqrImageCollection = imagespace.collections.ImageCollection.extend({
+    altUrl: 'smqtk_iqr/results'
+});

--- a/imagespace_smqtk/web_client/js/IqrSessionModel.js
+++ b/imagespace_smqtk/web_client/js/IqrSessionModel.js
@@ -1,0 +1,51 @@
+imagespace.models.IqrSessionModel = girder.models.ItemModel.extend({
+    altUrl: 'smqtk_iqr/session',
+
+    // This is adapted from girder.models.MetadataMixin
+    // It needs to be copied because we want to update the IQR session metadata
+    // which needs to be updated at item/:id/metadata instead of smqtk_iqr/session/:id/metadata
+    _sendMetadata: function (metadata, successCallback, errorCallback) {
+        girder.restRequest({
+            path: this.resourceName + '/' + this.get('_id') + '/metadata',
+            contentType: 'application/json',
+            data: JSON.stringify(metadata),
+            type: 'PUT',
+            error: null
+        }).done(_.bind(function (resp) {
+            this.set('meta', resp.meta);
+            if (_.isFunction(successCallback)) {
+                successCallback();
+            }
+        }, this)).error(_.bind(function (err) {
+            err.message = err.responseJSON.message;
+            if (_.isFunction(errorCallback)) {
+                errorCallback(err);
+            }
+        }, this));
+    },
+
+    addPositiveUuid: function (uuid, done) {
+        var pos_uuids = this.get('meta').pos_uuids,
+            neg_uuids = this.get('meta').neg_uuids;
+
+        this.get('meta').pos_uuids = _.union(pos_uuids, [uuid]);
+        this.get('meta').neg_uuids = _.difference(neg_uuids, [uuid]);
+
+        this._sendMetadata(this.get('meta'), done);
+    },
+
+    addNegativeUuid: function (uuid, done) {
+        var pos_uuids = this.get('meta').pos_uuids,
+            neg_uuids = this.get('meta').neg_uuids;
+
+        this.get('meta').pos_uuids = _.difference(pos_uuids, [uuid]);
+        this.get('meta').neg_uuids = _.union(neg_uuids, [uuid]);
+
+        this._sendMetadata(this.get('meta'), done);
+    }
+});
+
+imagespace.collections.IqrSessionCollection = girder.collections.ItemCollection.extend({
+    model: imagespace.models.IqrSessionModel,
+    altUrl: 'smqtk_iqr/session'
+});

--- a/imagespace_smqtk/web_client/js/IqrSessionModel.js
+++ b/imagespace_smqtk/web_client/js/IqrSessionModel.js
@@ -34,6 +34,13 @@ imagespace.models.IqrSessionModel = girder.models.ItemModel.extend({
         this._sendMetadata(this.get('meta'), done);
     },
 
+    removePositiveUuid: function (uuid, done) {
+        var pos_uuids = this.get('meta').pos_uuids;
+
+        this.get('meta').pos_uuids = _.difference(pos_uuids, [uuid]);
+        this._sendMetadata(this.get('meta'), done);
+    },
+
     addNegativeUuid: function (uuid, done) {
         var pos_uuids = this.get('meta').pos_uuids,
             neg_uuids = this.get('meta').neg_uuids;
@@ -41,6 +48,13 @@ imagespace.models.IqrSessionModel = girder.models.ItemModel.extend({
         this.get('meta').pos_uuids = _.difference(pos_uuids, [uuid]);
         this.get('meta').neg_uuids = _.union(neg_uuids, [uuid]);
 
+        this._sendMetadata(this.get('meta'), done);
+    },
+
+    removeNegativeUuid: function (uuid, done) {
+        var neg_uuids = this.get('meta').neg_uuids;
+
+        this.get('meta').neg_uuids = _.difference(neg_uuids, [uuid]);
         this._sendMetadata(this.get('meta'), done);
     }
 });

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -40,6 +40,12 @@ girder.events.once('im:appload.after', function () {
 
                     if (_.isUndefined(session)) {
                         console.error('Unable to find IQR session in client side representation');
+                    } else {
+                        // @todo this should be handled properly with defaults
+                        session.set('meta', session.get('meta') || {
+                            pos_uuids: [],
+                            neg_uuids: []
+                        });
                     }
                 }
 
@@ -70,9 +76,6 @@ girder.events.once('im:appload.after', function () {
      * IQR Image Collection instead.
      **/
     imagespace.smqtk.iqr.RefineView = _.bind(function () {
-        // If navigating to an IQR session via permalink, cancel the existing search
-        girder.cancelRestRequests('fetch');
-
         if (_.has(imagespace, 'searchView')) {
             imagespace.searchView.destroy();
         }
@@ -118,7 +121,10 @@ girder.events.once('im:appload.after', function () {
 
     girder.wrap(imagespace.views.LayoutHeaderView, 'render', function (render, settings) {
         render.call(this, settings);
-        imagespace.smqtk.iqr.refiningNotice(true);
+
+        if (imagespace.smqtk.iqr.currentIqrSession) {
+            imagespace.smqtk.iqr.refiningNotice(true);
+        }
 
         return this;
     });
@@ -144,6 +150,9 @@ girder.events.once('im:appload.after', function () {
 
                 $(captionDiv).replaceWith(annotationWidgetView.render().el);
             }, this));
+
+            $('#im-classification-narrow').hide();
+            $('#smqtk-near-duplicates').hide();
         }
 
         return this;

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -56,11 +56,27 @@ girder.events.once('im:appload.after', function () {
 
             refiningNotice: function (enable) {
                 if (enable && imagespace.smqtk.iqr.currentIqrSession !== false) {
-                    $('nav.navbar-fixed-top').append(girder.templates.iqrNotice());
+                    if (!_.has(imagespace.smqtk.iqr, 'iqrNoticeView') || _.isUndefined(imagespace.smqtk.iqr.iqrNoticeView)) {
+                        imagespace.smqtk.iqr.iqrNoticeView = new imagespace.views.IqrNoticeView({
+                            parentView: null
+                        });
+
+                        $('nav.navbar-fixed-top').append(imagespace.smqtk.iqr.iqrNoticeView.render().el);
+                    }
+
                     $('#wrapper').css('margin-top', '80px');
+                    $('#im-classification-narrow').hide();
+                    $('#smqtk-near-duplicates').hide();
                 } else {
-                    $('nav.navbar-fixed-top .smqtk-iqr-notice').remove();
+                    if (_.has(imagespace.smqtk.iqr, 'iqrNoticeView') &&
+                        !_.isUndefined(imagespace.smqtk.iqr.iqrNoticeView)) {
+                        imagespace.smqtk.iqr.iqrNoticeView.destroy();
+                        imagespace.smqtk.iqr.iqrNoticeView = undefined;
+                    }
+
                     $('#wrapper').css('margin-top', '');
+                    $('#im-classification-narrow').show();
+                    $('#smqtk-near-duplicates').show();
                 }
             }
         }
@@ -119,16 +135,6 @@ girder.events.once('im:appload.after', function () {
         }
     });
 
-    girder.wrap(imagespace.views.LayoutHeaderView, 'render', function (render, settings) {
-        render.call(this, settings);
-
-        if (imagespace.smqtk.iqr.currentIqrSession) {
-            imagespace.smqtk.iqr.refiningNotice(true);
-        }
-
-        return this;
-    });
-
     girder.wrap(imagespace.views.SearchView, 'render', function (render) {
         render.call(this);
 
@@ -151,8 +157,7 @@ girder.events.once('im:appload.after', function () {
                 $(captionDiv).replaceWith(annotationWidgetView.render().el);
             }, this));
 
-            $('#im-classification-narrow').hide();
-            $('#smqtk-near-duplicates').hide();
+            imagespace.smqtk.iqr.refiningNotice(true);
         }
 
         return this;
@@ -174,8 +179,6 @@ girder.events.once('im:appload.after', function () {
 
             imagespace.smqtk.iqr.sessions.add(iqrSession);
             imagespace.smqtk.iqr.currentIqrSession = iqrSession;
-            // @todo this should be an update to the headerView render
-            imagespace.smqtk.iqr.refiningNotice(true);
             imagespace.searchView.render();
         }, this));
     };

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -163,6 +163,8 @@ girder.events.once('im:appload.after', function () {
             return;
         }
 
+        $('#smqtk-iqr-action button').append('    <i class="icon-spin5 animate-spin"></i>');
+
         girder.restRequest({
             path: 'smqtk_iqr/refine',
             type: 'PUT',

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -1,0 +1,141 @@
+/**
+ * This is responsible for the IQR integration of the SMQTK ImageSpace plugin.
+ * This adds 2 new events, 1 new route, and wraps an existing method:
+ * New events:
+ * 1) Click to start a new IQR session
+ *    This creates an IQR session on the server side and re-renders the search view.
+ * 2) Click to refine an existing IQR session
+ *    When the user has initialized an IQR session and selected some pos/negative examples
+ *    and want to refine it will PUT to the refine endpoint and then change the URL
+ *    to enter the main entrypoint (fetching the new results).
+ *    In a refined state pagination will still work since the collection is now an IqrImageCollection.
+ * New route:
+ *   The refine route mimics the search route with the exception of the classification parameter
+ *   having no effect and should be removed. This is in place just so the user can permalink
+ *   results from a given refinement.
+ * Wrapping SearchView.render:
+ *   This is wrapped to replace the captions of Image results with an AnnotationWidgetView
+ *   when the user is in an IQR session.
+ **/
+girder.events.once('im:appload.after', function () {
+    imagespace.smqtk = imagespace.smqtk || {
+        iqr: {
+            sessions: new imagespace.collections.IqrSessionCollection(),
+
+            /**
+             * Returns the IqrSessionModel representing the current IQR session (via the query string).
+             * IQR is currently limited to logged in users.
+             **/
+            currentIqrSession: function () {
+                var qs = imagespace.parseQueryString(),
+                    session;
+
+                if (girder.currentUser && _.has(qs, 'smqtk_iqr_session')) {
+                    session = _.find(imagespace.smqtk.iqr.sessions.models, function (iqrSession) {
+                        return iqrSession.get('name') === qs.smqtk_iqr_session;
+                    });
+
+                    if (_.isUndefined(session)) {
+                        console.error('Unable to find IQR session in client side representation');
+                    }
+                }
+
+                return session || false;
+            }
+        }
+    };
+
+    // @todo This route should probably be clarified, an iqr_session_id parameter is required
+    imagespace.router.route('refine/:query(/params/:params)', 'refine', function (query, params) {
+        imagespace.smqtk.iqr.sessions.fetch();
+        imagespace.smqtk.iqr.sessions.once('g:changed', _.bind(function () {
+            imagespace.headerView.render({query: query});
+
+            if (_.has(imagespace, 'searchView')) {
+                imagespace.searchView.destroy();
+            }
+
+            // @todo pass these into the constructor properly
+            var coll = new imagespace.collections.IqrImageCollection();
+            coll.params = coll.params || {};
+            coll.params.sid = imagespace.smqtk.iqr.currentIqrSession().get('name');
+
+            imagespace.searchView = new imagespace.views.SearchView({
+                parentView: this.parentView,
+                collection: coll
+            });
+            coll.fetch(coll.params || {});
+        }, this));
+    });
+
+    girder.wrap(imagespace.views.SearchView, 'render', function (render) {
+        render.call(this);
+
+        var currentIqrSession = imagespace.smqtk.iqr.currentIqrSession();
+        this.$('.pull-right').append(girder.templates.startIqrSession({
+            currentIqrSession: currentIqrSession
+        }));
+
+        if (currentIqrSession) {
+            // Render annotation widgets on each image (replacing the caption utilities)
+            _.each(this.$('.im-caption'), _.bind(function (captionDiv, i) {
+                var annotationWidgetView = new imagespace.views.AnnotationWidgetView({
+                    /**
+                     * The parent of the annotation widget should be the individual image view.
+                     * Since `this` references the SearchView - we actually want the child view
+                     * that represents the i'th image.
+                     **/
+                    parentView: this.getChildImageView(i)
+                });
+
+                $(captionDiv).replaceWith(annotationWidgetView.render().el);
+            }, this));
+        }
+    });
+
+    // create new iqr session, re-render search view with an iqr image collection
+    imagespace.views.SearchView.prototype.events['click #smqtk-iqr-start-session'] = function (event) {
+        var iqrSession = new imagespace.models.IqrSessionModel({
+            meta: {
+                pos_uuids: [],
+                neg_uuids: []
+            }
+        });
+
+        iqrSession.save().once('g:saved', _.bind(function () {
+            imagespace.updateQueryParams({
+                smqtk_iqr_session: iqrSession.get('name')
+            });
+
+            imagespace.searchView.render();
+        }, this));
+
+        imagespace.smqtk.iqr.sessions.add(iqrSession);
+    };
+
+    imagespace.views.SearchView.prototype.events['click #smqtk-iqr-refine'] = function (event) {
+        var session = imagespace.smqtk.iqr.currentIqrSession();
+
+        if (_.size(session.get('meta').pos_uuids) === 0 &&
+            _.size(session.get('meta').neg_uuids) === 0) {
+            alert('Refinement requires at least 1 positive or negative example.');
+            return;
+        }
+
+        girder.restRequest({
+            path: 'smqtk_iqr/refine',
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                sid: session.get('name'),
+                pos_uuids: session.get('meta').pos_uuids,
+                neg_uuids: session.get('meta').neg_uuids
+            })
+        }).done(function () {
+            var searchQuery = _.first(imagespace.getQueryTypeWithArguments(true));
+            imagespace.router.navigate('refine/' + searchQuery + '/params/smqtk_iqr_session=' + session.get('name'), {
+                trigger: true
+            });
+        }).error(console.error);
+    };
+});

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -129,9 +129,8 @@ girder.events.once('im:appload.after', function () {
     imagespace.views.SearchView.prototype.events['click #smqtk-iqr-refine'] = function (event) {
         var session = imagespace.smqtk.iqr.currentIqrSession;
 
-        if (_.size(session.get('meta').pos_uuids) === 0 &&
-            _.size(session.get('meta').neg_uuids) === 0) {
-            alert('Refinement requires at least 1 positive or negative example.');
+        if (_.size(session.get('meta').pos_uuids) === 0) {
+            alert('Refinement requires at least 1 positive example.');
             return;
         }
 

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -105,12 +105,12 @@ girder.events.once('im:appload.after', function () {
             parentView: this.parentView,
             collection: coll
         });
-        coll.fetch(coll.params || {});
+        coll.fetch(coll.params || {}, true);
     }, this);
 
     imagespace.smqtk.iqr.createOrUpdateRefineView = function () {
         if (imagespace.searchView.collection instanceof imagespace.collections.IqrImageCollection) {
-            imagespace.searchView.collection.fetch(imagespace.searchView.collection.params || {});
+            imagespace.searchView.collection.fetch(imagespace.searchView.collection.params || {}, true);
         } else {
             imagespace.smqtk.iqr.RefineView();
         }

--- a/imagespace_smqtk/web_client/js/iqrNoticeView.js
+++ b/imagespace_smqtk/web_client/js/iqrNoticeView.js
@@ -1,0 +1,19 @@
+imagespace.views.IqrNoticeView = imagespace.View.extend({
+    events: {
+        'click .smqtk-iqr-quit-session': function (e) {
+            if (_.has(imagespace.parseQueryString(), 'smqtk_iqr_session')) {
+                imagespace.smqtk.iqr.currentIqrSession = false;
+                imagespace.smqtk.iqr.refiningNotice(false);
+                imagespace.setQueryParams(_.omit(imagespace.parseQueryString(),
+                                                 ['smqtk_iqr_session']), {
+                                                     trigger: true
+                                                 });
+            }
+        }
+    },
+
+    render: function () {
+        this.$el.html(girder.templates.iqrNotice());
+        return this;
+    }
+});

--- a/imagespace_smqtk/web_client/stylesheets/smqtk.styl
+++ b/imagespace_smqtk/web_client/stylesheets/smqtk.styl
@@ -12,3 +12,7 @@
 
 .smqtk-iqr-annotation button.smqtk-iqr-negative
   background-color #cc7f7f
+
+.smqtk-iqr-notice
+  text-align center
+  padding 5px

--- a/imagespace_smqtk/web_client/stylesheets/smqtk.styl
+++ b/imagespace_smqtk/web_client/stylesheets/smqtk.styl
@@ -1,5 +1,6 @@
 .smqtk-iqr-annotation
   margin-left 40px
+  height 60px
 
 .smqtk-iqr-annotation button
   opacity .5

--- a/imagespace_smqtk/web_client/stylesheets/smqtk.styl
+++ b/imagespace_smqtk/web_client/stylesheets/smqtk.styl
@@ -21,6 +21,9 @@
   text-align center
   padding 5px
 
+.smqtk-iqr-quit-session
+  cursor pointer
+
 // Extend ImageSpace defaults
 #search-controls
   height 90px !important

--- a/imagespace_smqtk/web_client/stylesheets/smqtk.styl
+++ b/imagespace_smqtk/web_client/stylesheets/smqtk.styl
@@ -1,0 +1,14 @@
+.smqtk-iqr-annotation
+  margin-left 40px
+
+.smqtk-iqr-annotation button
+  opacity .5
+
+.smqtk-iqr-annotation button.selected
+  opacity 1
+
+.smqtk-iqr-annotation button.smqtk-iqr-positive
+  background-color #95cd7e
+
+.smqtk-iqr-annotation button.smqtk-iqr-negative
+  background-color #cc7f7f

--- a/imagespace_smqtk/web_client/stylesheets/smqtk.styl
+++ b/imagespace_smqtk/web_client/stylesheets/smqtk.styl
@@ -14,6 +14,13 @@
 .smqtk-iqr-annotation button.smqtk-iqr-negative
   background-color #cc7f7f
 
+#smqtk-iqr-action button
+  margin-top 5px
+
 .smqtk-iqr-notice
   text-align center
   padding 5px
+
+// Extend ImageSpace defaults
+#search-controls
+  height 90px !important

--- a/imagespace_smqtk/web_client/templates/iqrAnnotationWidget.jade
+++ b/imagespace_smqtk/web_client/templates/iqrAnnotationWidget.jade
@@ -1,6 +1,5 @@
-.smqtk-iqr-annotation
-  .btn-group
-    button.btn.btn-default.smqtk-iqr-annotate.smqtk-iqr-positive(class=(positive ? 'selected' : ''))
-      | Pos
-    button.btn.btn-default.smqtk-iqr-annotate.smqtk-iqr-negative(class=(negative ? 'selected' : ''))
-      | Neg
+.btn-group
+  button.btn.btn-default.smqtk-iqr-annotate.smqtk-iqr-positive(class=(positive ? 'selected' : ''))
+    | Pos
+  button.btn.btn-default.smqtk-iqr-annotate.smqtk-iqr-negative(class=(negative ? 'selected' : ''))
+    | Neg

--- a/imagespace_smqtk/web_client/templates/iqrAnnotationWidget.jade
+++ b/imagespace_smqtk/web_client/templates/iqrAnnotationWidget.jade
@@ -1,0 +1,6 @@
+.smqtk-iqr-annotation
+  .btn-group
+    button.btn.btn-default.smqtk-iqr-annotate.smqtk-iqr-positive(class=(positive ? 'selected' : ''))
+      | Pos
+    button.btn.btn-default.smqtk-iqr-annotate.smqtk-iqr-negative(class=(negative ? 'selected' : ''))
+      | Neg

--- a/imagespace_smqtk/web_client/templates/iqrNotice.jade
+++ b/imagespace_smqtk/web_client/templates/iqrNotice.jade
@@ -1,2 +1,2 @@
 .im-alert.alert.alert-warning.smqtk-iqr-notice
-  | In IQR Refinement Session
+  | In Interactive Refinement Session

--- a/imagespace_smqtk/web_client/templates/iqrNotice.jade
+++ b/imagespace_smqtk/web_client/templates/iqrNotice.jade
@@ -1,2 +1,3 @@
 .im-alert.alert.alert-warning.smqtk-iqr-notice
   | In Interactive Refinement Session
+  i.icon-cancel.smqtk-iqr-quit-session

--- a/imagespace_smqtk/web_client/templates/iqrNotice.jade
+++ b/imagespace_smqtk/web_client/templates/iqrNotice.jade
@@ -1,2 +1,2 @@
-.im-alert.alert.alert-warning
+.im-alert.alert.alert-warning.smqtk-iqr-notice
   | In IQR Refinement Session

--- a/imagespace_smqtk/web_client/templates/iqrNotice.jade
+++ b/imagespace_smqtk/web_client/templates/iqrNotice.jade
@@ -1,0 +1,2 @@
+.im-alert.alert.alert-warning
+  | In IQR Refinement Session

--- a/imagespace_smqtk/web_client/templates/startIqrSession.jade
+++ b/imagespace_smqtk/web_client/templates/startIqrSession.jade
@@ -1,0 +1,7 @@
+#smqtk-iqr-action
+  if currentIqrSession === false
+    button.btn.btn-default#smqtk-iqr-start-session(style='display:block')
+      | Start IQR Session
+  else
+    button.btn.btn-default.btn-primary#smqtk-iqr-refine(style='display:block')
+      | Refine

--- a/imagespace_smqtk/web_client/templates/startIqrSession.jade
+++ b/imagespace_smqtk/web_client/templates/startIqrSession.jade
@@ -1,6 +1,6 @@
 #smqtk-iqr-action
   if currentIqrSession === false
-    button.btn.btn-default#smqtk-iqr-start-session(style='display:block')
+    button.btn.btn-default#smqtk-iqr-start-session(style='display:block', title='Start Interactive Query Refinement Session')
       | Start IQR Session
   else
     button.btn.btn-default.btn-primary#smqtk-iqr-refine(style='display:block')

--- a/imagespace_weapons/server/__init__.py
+++ b/imagespace_weapons/server/__init__.py
@@ -21,7 +21,10 @@ from girder import events
 
 
 def add_maintype_to_qparams(event):
-    event.info['fq'] = ['mainType:image']
+    if 'fq' not in event.info:
+        event.info['fq'] = []
+
+    event.info['fq'].append('mainType:image')
     event.addResponse(event.info)
 
 def uppercase_basename_for_resourcenames(event):


### PR DESCRIPTION
This is definitely a work in progress, but a usable implementation.

A few things to note:
- This branch includes PR #152 as it needed the helper function `solr_documents_from_field`
- This branch depends on girder/girder#1261
- User uploaded images can't be used for adjudication just yet
- The UI is ugly right now

The flow of how this works:
1) From any results view in ImageSpace an IQR session can be started from the top right
2) Once an IQR session is started - saving and searching based on an image is disabled, those buttons are replaced with an annotation widget that lets the user choose whether the image is positive or negative.
3) Once the user has selected enough of the images they want, they can hit the Refine button on the top right and they will be in a "refine" mode - from here they can only look through the refinement results and add more positive/negative results and further refine.

Left to do:
- [x] Clean up the UI
- [x] Make it clear the user is in refinement mode
- [x] Support removing images from positive/negative (i.e. clicking positive on a positive labeled image should make it neutral)
- [ ] Allow user uploads to be used for refinement (this is more on Paul)
- [ ] Allow saving/application of classifiers
- [x] Allow cancellation of refinement in initial stage
- [x] Call it "Interactive Refinement" instead of IQR for clarity
- [x] Gun type checkboxes do not work in refinement mode - make them work or hide them

@jeffbaumes Feel free to review if you want (noting the Girder dependency) and add any tasks you think need to be added.
