### PR TITLE
Fix the back button not working when on first page of search results

### DIFF
--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -186,18 +186,21 @@ _.extend(imagespace, {
      * in the URL query string and navigates there using the imagespace router.
      * Routes aren't triggered, it is a silent navigation.
      **/
-    updateQueryParams: function (params) {
+    updateQueryParams: function (params, skipHistory) {
         var hash = Backbone.history.getHash(),
             paramsStartIndex = hash.indexOf('/params/'),
             qs = (paramsStartIndex !== -1) ?
                   hash.substr(paramsStartIndex).replace('/params/', '') : '',
             qsObj = imagespace.parseQueryString(qs),
             hashBeforeParams = (paramsStartIndex !== -1) ?
-                                hash.substr(0, paramsStartIndex) : hash;
+                                hash.substr(0, paramsStartIndex) : hash,
+            replace = !!skipHistory;
 
         _.extend(qsObj, params);
 
-        imagespace.router.navigate(hashBeforeParams + '/params/' + imagespace.createQueryString(qsObj));
+        imagespace.router.navigate(hashBeforeParams + '/params/' + imagespace.createQueryString(qsObj), {
+            replace: replace
+        });
     },
 
     oppositeCaseFilename: function (filename) {

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -40,9 +40,13 @@ imagespace.views.SearchView = imagespace.View.extend({
             this.render();
 
             if (this.collection.supportsPagination) {
+                /**
+                 * In the case of coercing a search to be page 1, skip adding both the unpaginated
+                 * and paginated URLs to the history (breaking the back button).
+                 **/
                 imagespace.updateQueryParams({
                     page: this.collection.pageNum() + 1
-                });
+                }, this.collection.pageNum() == 0);
             }
 
             $('.alert-info').addClass('hidden');


### PR DESCRIPTION
An initial search coerces the URL to append a page=1, without using the
Backbone replace option it counted both search and search/page=1 as
history entries meaning the back button would redirect to page=1.

@jeffbaumes 
