### PR TITLE
Fix token splitting

### DIFF
--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -110,12 +110,12 @@ imagespace.router.route('search/:query(/params/:params)', 'search', function (qu
 imagespace.router.route('search/:url/:mode(/params/:params)', 'search', function (url, mode, params) {
     // Replace Girder token with current session's token if necessary
     var niceName = (_.has(imagespace.searches[mode], 'niceName')) ? imagespace.searches[mode].niceName : mode,
-        parts = url.split('&token=');
+        parts = url.split('?token=');
 
     $('.alert-info').html('Performing ' + niceName  + ' search <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
 
     if (parts.length === 2) {
-        url = parts[0] + '&token=' + girder.cookie.find('girderToken');
+        url = parts[0] + '?token=' + girder.cookie.find('girderToken');
     }
 
     var performSearch = function (image) {

--- a/imagespace/web_external/js/views/layout/UserDataView.js
+++ b/imagespace/web_external/js/views/layout/UserDataView.js
@@ -50,9 +50,9 @@ imagespace.views.LayoutUserDataView = imagespace.View.extend({
                             }
 
                             // Replace Girder token with current session's token if necessary
-                            parts = item.meta.imageUrl.split('&token=');
+                            parts = item.meta.imageUrl.split('?token=');
                             if (parts.length === 2) {
-                                imageModel.set('imageUrl', parts[0] + '&token=' + girder.cookie.find('girderToken'));
+                                models[models.length - 1].set('imageUrl', parts[0] + '?token=' + girder.cookie.find('girderToken'));
                             }
                         }
                     }, this));


### PR DESCRIPTION
Girder image urls only append the token, so a question mark is needed instead of an ampersand.

This also fixes a bug where the `imageModel` variable is undefined, triggering an error when that codepath is executed.

Still trying to figure out why the `imageModel` code path only started getting executed recently.
