### PR TITLE
Allow user to save IQR sessions

### DIFF
--- a/imagespace/web_external/js/main.js
+++ b/imagespace/web_external/js/main.js
@@ -28,8 +28,14 @@ $(function () {
         imagespace.events.trigger('g:appload.before');
         window.app = new imagespace.App({
             el: 'body',
-            parentView: null
+            parentView: null,
+            start: false
         });
+
+        window.app.start().then(function () {
+            girder.events.trigger('g:appload.ready');
+        });
+
         imagespace.events.trigger('g:appload.after');
         girder.events.trigger('im:appload.after');
     });

--- a/imagespace/web_external/stylesheets/layout.styl
+++ b/imagespace/web_external/stylesheets/layout.styl
@@ -120,7 +120,6 @@ $headerHeight = 50px
 
 .im-view-mode
     padding-right 40px
-    padding-bottom 20px
 
 .im-search-image
     height 50px

--- a/imagespace/web_external/templates/body/search.jade
+++ b/imagespace/web_external/templates/body/search.jade
@@ -18,16 +18,17 @@
         .im-pagination-container
         p Showing results #{startIndex + 1} - #{toIndex} of #{total}
 
-    .im-view-mode.pull-right
-      .btn-group(data-toggle="buttons")
-        label.btn.btn-default(class=(viewMode === 'grid' ? 'active' : ''))
-          input.im-view-grid(type="radio", name="options", autocomplete="off", checked=(viewMode === 'grid' ? 'true' : null))
-          i.icon-th
-          | &nbsp;Grid
-        label.btn.btn-default(class=(viewMode === 'list' ? 'active' : ''))
-          input.im-view-list(type="radio", name="options", autocomplete="off", checked=(viewMode === 'list' ? 'true' : null))
-          i.icon-th-list
-          | &nbsp;List
+    .right-search-controls.pull-right
+      .im-view-mode
+        .btn-group(data-toggle="buttons")
+          label.btn.btn-default(class=(viewMode === 'grid' ? 'active' : ''))
+            input.im-view-grid(type="radio", name="options", autocomplete="off", checked=(viewMode === 'grid' ? 'true' : null))
+            i.icon-th
+            | &nbsp;Grid
+          label.btn.btn-default(class=(viewMode === 'list' ? 'active' : ''))
+            input.im-view-list(type="radio", name="options", autocomplete="off", checked=(viewMode === 'list' ? 'true' : null))
+            i.icon-th-list
+            | &nbsp;List
 
   #im-search-results
     if !collection.length

--- a/imagespace_smqtk/server/smqtk_iqr.py
+++ b/imagespace_smqtk/server/smqtk_iqr.py
@@ -40,6 +40,7 @@ class SmqtkIqr(Resource):
         self.resourceName = 'smqtk_iqr'
         self.route('POST', ('session',), self.createSession)
         self.route('GET', ('session',), self.getSessions)
+        self.route('GET', ('session_folder',), self.getSessionFolder)
         self.route('PUT', ('refine',), self.refine)
         self.route('GET', ('results',), self.results)
 
@@ -50,6 +51,11 @@ class SmqtkIqr(Resource):
     def getSessions(self, params):
         sessionsFolder = getCreateSessionsFolder()
         return list(ModelImporter.model('folder').childItems(folder=sessionsFolder))
+
+    @access.user
+    @describeRoute(Description('Get session folder'))
+    def getSessionFolder(self, params):
+        return getCreateSessionsFolder()
 
     @access.user
     @describeRoute(

--- a/imagespace_smqtk/server/smqtk_iqr.py
+++ b/imagespace_smqtk/server/smqtk_iqr.py
@@ -19,8 +19,8 @@
 
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource
-
+from girder.api.rest import Resource, filtermodel, loadmodel
+from girder.constants import AccessType, TokenScope
 from girder.utility.model_importer import ModelImporter
 from girder.api.rest import getBodyJson, getCurrentUser
 
@@ -40,6 +40,7 @@ class SmqtkIqr(Resource):
         self.resourceName = 'smqtk_iqr'
         self.route('POST', ('session',), self.createSession)
         self.route('GET', ('session',), self.getSessions)
+        self.route('PUT', ('session', ':id'), self.updateSession)
         self.route('GET', ('session_folder',), self.getSessionFolder)
         self.route('PUT', ('refine',), self.refine)
         self.route('GET', ('results',), self.results)
@@ -64,12 +65,36 @@ class SmqtkIqr(Resource):
     def createSession(self, params):
         sessionsFolder = getCreateSessionsFolder()
         sessionId = requests.post(self.search_url + '/session').json()['sid']
-        return ModelImporter.model('item').createItem(name=sessionId,
+        item = ModelImporter.model('item').createItem(name=sessionId,
                                                       creator=getCurrentUser(),
                                                       folder=sessionsFolder)
+        ModelImporter.model('item').setMetadata(item, {
+            'sid': sessionId
+        })
+
+        return item
         # create sessions folder in private directory if not existing
         # post to init_session, get sid back
         # create item named sid in sessions folder
+
+    @access.user(scope=TokenScope.DATA_WRITE)
+    @loadmodel(model='item', level=AccessType.WRITE)
+    @filtermodel(model='item')
+    @describeRoute(
+        Description('Update a session item')
+        .responseClass('Item')
+        .param('id', 'The ID of the item.', paramType='path')
+        .param('name', 'Name for the item.', required=False)
+        .param('description', 'Description for the item.', required=False)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Write access was denied for the item or folder.', 403))
+    def updateSession(self, item, params):
+        item['name'] = params.get('name', item['name']).strip()
+        item['description'] = params.get(
+            'description', item['description']).strip()
+
+        self.model('item').updateItem(item)
+        return item
 
     @access.user
     @describeRoute(

--- a/imagespace_smqtk/server/utils.py
+++ b/imagespace_smqtk/server/utils.py
@@ -1,6 +1,8 @@
 from girder.utility.model_importer import ModelImporter
-from girder.api.rest import getCurrentUser
+from girder.api.rest import getCurrentUser, filtermodel
 
+
+@filtermodel(model='folder')
 def getCreateSessionsFolder():
     user = getCurrentUser()
     folder = ModelImporter.model('folder')

--- a/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
+++ b/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
@@ -10,7 +10,8 @@ imagespace.views.IqrSelectSessionView = imagespace.View.extend({
                 imagespace.smqtk.iqr.currentIqrSession = new imagespace.models.IqrSessionModel(item.attributes);
 
                 imagespace.updateQueryParams({
-                    smqtk_iqr_session: item.get('name')
+                    page: 1,
+                    smqtk_iqr_session: item.get('meta').sid
                 }, { trigger: true });
 
                 $('.modal-header button[data-dismiss="modal"]').click()

--- a/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
+++ b/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
@@ -7,6 +7,7 @@ imagespace.views.IqrSelectSessionView = imagespace.View.extend({
             showActions: true,
             checkboxes: true,
             onItemClick: function (item) {
+                imagespace.smqtk.iqr.refiningNotice(false);
                 imagespace.smqtk.iqr.currentIqrSession = new imagespace.models.IqrSessionModel(item.attributes);
 
                 imagespace.updateQueryParams({
@@ -14,7 +15,7 @@ imagespace.views.IqrSelectSessionView = imagespace.View.extend({
                     smqtk_iqr_session: item.get('meta').sid
                 }, { trigger: true });
 
-                $('.modal-header button[data-dismiss="modal"]').click()
+                $('.modal-header button[data-dismiss="modal"]').click();
             }
         });
         return this;

--- a/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
+++ b/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
@@ -4,8 +4,8 @@ imagespace.views.IqrSelectSessionView = imagespace.View.extend({
         this.hierarchyView = new girder.views.HierarchyWidget({
             parentView: this,
             parentModel: this.folder,
-            showActions: false,
-            checkboxes: false,
+            showActions: true,
+            checkboxes: true,
             onItemClick: function (item) {
                 imagespace.smqtk.iqr.currentIqrSession = new imagespace.models.IqrSessionModel(item.attributes);
 

--- a/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
+++ b/imagespace_smqtk/web_client/js/IqrSelectSessionView.js
@@ -1,0 +1,27 @@
+imagespace.views.IqrSelectSessionView = imagespace.View.extend({
+    initialize: function (settings) {
+        this.folder = settings.folder;
+        this.hierarchyView = new girder.views.HierarchyWidget({
+            parentView: this,
+            parentModel: this.folder,
+            showActions: false,
+            checkboxes: false,
+            onItemClick: function (item) {
+                imagespace.smqtk.iqr.currentIqrSession = new imagespace.models.IqrSessionModel(item.attributes);
+
+                imagespace.updateQueryParams({
+                    smqtk_iqr_session: item.get('name')
+                }, { trigger: true });
+
+                $('.modal-header button[data-dismiss="modal"]').click()
+            }
+        });
+        return this;
+    },
+
+    render: function () {
+        this.$el.html(girder.templates.iqrSelectSession({})).girderModal(this);
+        this.hierarchyView.setElement(this.$('.im-hierarchy-widget')).render();
+        return this;
+    }
+});

--- a/imagespace_smqtk/web_client/js/IqrSessionModel.js
+++ b/imagespace_smqtk/web_client/js/IqrSessionModel.js
@@ -25,8 +25,8 @@ imagespace.models.IqrSessionModel = girder.models.ItemModel.extend({
     },
 
     addPositiveUuid: function (uuid, done) {
-        var pos_uuids = this.get('meta').pos_uuids,
-            neg_uuids = this.get('meta').neg_uuids;
+        var pos_uuids = this.get('meta').pos_uuids || [],
+            neg_uuids = this.get('meta').neg_uuids || [];
 
         this.get('meta').pos_uuids = _.union(pos_uuids, [uuid]);
         this.get('meta').neg_uuids = _.difference(neg_uuids, [uuid]);
@@ -35,15 +35,15 @@ imagespace.models.IqrSessionModel = girder.models.ItemModel.extend({
     },
 
     removePositiveUuid: function (uuid, done) {
-        var pos_uuids = this.get('meta').pos_uuids;
+        var pos_uuids = this.get('meta').pos_uuids || [];
 
         this.get('meta').pos_uuids = _.difference(pos_uuids, [uuid]);
         this._sendMetadata(this.get('meta'), done);
     },
 
     addNegativeUuid: function (uuid, done) {
-        var pos_uuids = this.get('meta').pos_uuids,
-            neg_uuids = this.get('meta').neg_uuids;
+        var pos_uuids = this.get('meta').pos_uuids || [],
+            neg_uuids = this.get('meta').neg_uuids || [];
 
         this.get('meta').pos_uuids = _.difference(pos_uuids, [uuid]);
         this.get('meta').neg_uuids = _.union(neg_uuids, [uuid]);
@@ -52,7 +52,7 @@ imagespace.models.IqrSessionModel = girder.models.ItemModel.extend({
     },
 
     removeNegativeUuid: function (uuid, done) {
-        var neg_uuids = this.get('meta').neg_uuids;
+        var neg_uuids = this.get('meta').neg_uuids || [];
 
         this.get('meta').neg_uuids = _.difference(neg_uuids, [uuid]);
         this._sendMetadata(this.get('meta'), done);

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -30,9 +30,8 @@
  * 3) Wrapping ItemListWidget.render:
  *    This is wrapped because of the Hierarchy Widget usage when loading an existing IQR session.
  *    For now, it's difficult to hook in to filter the items listed in the widget so we wrap render
- *    and remove the items we don't want (hacky). Specifically, we only want to show IQR sessions that have
- *    at least 1 positive or negative UUID and a name that isn't their SID (this is the indication that a user
- *    saved the session).
+ *    and remove the items we don't want (hacky). Specifically, we only want to show IQR sessions which
+ *    have a name that isn't their SID (this is the indication that a user saved the session).
  **/
 girder.events.once('im:appload.after', function () {
     imagespace.smqtk = imagespace.smqtk || {
@@ -239,9 +238,7 @@ girder.events.once('im:appload.after', function () {
 
         this.collection.models = _.filter(this.collection.models, function (model) {
             return model.has('meta') &&
-                model.get('name') != model.get('meta').sid &&
-                ((_.has(model.get('meta'), 'pos_uuids') && _.size(model.get('meta').pos_uuids)) ||
-                 (_.has(model.get('meta'), 'neg_uuids') && _.size(model.get('meta').neg_uuids)));
+                model.get('name') != model.get('meta').sid
         });
 
         return this;

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -82,13 +82,11 @@ girder.events.once('im:appload.after', function () {
         }
     };
 
-    if (girder.currentUser !== null) {
-        imagespace.smqtk.iqr.sessions.fetch();
-    } else {
-        girder.events.on('g:login.success', function () {
+    girder.events.on('g:appload.ready', function () {
+        if (girder.currentUser !== null) {
             imagespace.smqtk.iqr.sessions.fetch();
-        });
-    }
+        }
+    });
 
     imagespace.smqtk.iqr.sessions.once('g:changed', function () {
         imagespace.smqtk.iqr.currentIqrSession = imagespace.smqtk.iqr.findIqrSession();

--- a/imagespace_smqtk/web_client/js/iqr.js
+++ b/imagespace_smqtk/web_client/js/iqr.js
@@ -92,6 +92,17 @@ girder.events.once('im:appload.after', function () {
                     $('#im-classification-narrow').show();
                     $('#smqtk-near-duplicates').show();
                 }
+            },
+
+            quitIqrSession: function () {
+                if (_.has(imagespace.parseQueryString(), 'smqtk_iqr_session')) {
+                    imagespace.smqtk.iqr.currentIqrSession = false;
+                    imagespace.smqtk.iqr.refiningNotice(false);
+                    imagespace.setQueryParams(_.omit(imagespace.parseQueryString(),
+                                                     ['smqtk_iqr_session']), {
+                                                         trigger: true
+                                                     });
+                }
             }
         }
     };
@@ -159,12 +170,17 @@ girder.events.once('im:appload.after', function () {
         render.call(this);
 
         if (girder.currentUser !== null) {
-            this.$('.pull-right').append(girder.templates.startIqrSession({
+            this.$('#search-controls .right-search-controls').append(girder.templates.startIqrSession({
                 currentIqrSession: imagespace.smqtk.iqr.currentIqrSession
             }));
+
+            this.$('#smqtk-iqr-quit-session').on('click', imagespace.smqtk.iqr.quitIqrSession);
         }
 
         if (imagespace.smqtk.iqr.currentIqrSession) {
+            // Grid view is the only supported view for IQR, remove the view-mode controls
+            this.$('.im-view-mode').remove();
+
             // Render annotation widgets on each image (replacing the caption utilities)
             _.each(this.$('.im-caption'), _.bind(function (captionDiv, i) {
                 var annotationWidgetView = new imagespace.views.AnnotationWidgetView({
@@ -227,6 +243,8 @@ girder.events.once('im:appload.after', function () {
                 ((_.has(model.get('meta'), 'pos_uuids') && _.size(model.get('meta').pos_uuids)) ||
                  (_.has(model.get('meta'), 'neg_uuids') && _.size(model.get('meta').neg_uuids)));
         });
+
+        return this;
     });
 
     imagespace.views.SearchView.prototype.events['click #smqtk-iqr-refine'] = function (event) {

--- a/imagespace_smqtk/web_client/js/iqrNoticeView.js
+++ b/imagespace_smqtk/web_client/js/iqrNoticeView.js
@@ -1,14 +1,7 @@
 imagespace.views.IqrNoticeView = imagespace.View.extend({
     events: {
         'click .smqtk-iqr-quit-session': function (e) {
-            if (_.has(imagespace.parseQueryString(), 'smqtk_iqr_session')) {
-                imagespace.smqtk.iqr.currentIqrSession = false;
-                imagespace.smqtk.iqr.refiningNotice(false);
-                imagespace.setQueryParams(_.omit(imagespace.parseQueryString(),
-                                                 ['smqtk_iqr_session']), {
-                                                     trigger: true
-                                                 });
-            }
+            imagespace.smqtk.iqr.quitIqrSession();
         }
     },
 

--- a/imagespace_smqtk/web_client/js/iqrNoticeView.js
+++ b/imagespace_smqtk/web_client/js/iqrNoticeView.js
@@ -12,8 +12,16 @@ imagespace.views.IqrNoticeView = imagespace.View.extend({
         }
     },
 
+    initialize: function (settings) {
+        // The user might rename the session, so re-render this when it changes
+        this.listenTo(imagespace.smqtk.iqr.currentIqrSession, 'change', this.render);
+    },
+
     render: function () {
-        this.$el.html(girder.templates.iqrNotice());
+        this.$el.html(girder.templates.iqrNotice({
+            sessionName: imagespace.smqtk.iqr.currentIqrSession.get('name'),
+            sessionId: imagespace.smqtk.iqr.currentIqrSession.get('meta').sid
+        }));
         return this;
     }
 });

--- a/imagespace_smqtk/web_client/stylesheets/smqtk.styl
+++ b/imagespace_smqtk/web_client/stylesheets/smqtk.styl
@@ -27,3 +27,6 @@
 // Extend ImageSpace defaults
 #search-controls
   height 90px !important
+
+.smqtk-iqr-notice span
+  font-weight bold

--- a/imagespace_smqtk/web_client/templates/iqrNotice.jade
+++ b/imagespace_smqtk/web_client/templates/iqrNotice.jade
@@ -1,3 +1,8 @@
+if sessionId != sessionName
+  - var name = '(' + sessionName + ')'
+else
+  - var name = ''
+
 .im-alert.alert.alert-warning.smqtk-iqr-notice
-  | In Interactive Refinement Session
+  | In Interactive Refinement Session #{name}
   i.icon-cancel.smqtk-iqr-quit-session

--- a/imagespace_smqtk/web_client/templates/iqrNotice.jade
+++ b/imagespace_smqtk/web_client/templates/iqrNotice.jade
@@ -4,5 +4,6 @@ else
   - var name = ''
 
 .im-alert.alert.alert-warning.smqtk-iqr-notice
-  | In Interactive Refinement Session #{name}
+  | In Interactive Refinement Session
+  span  #{name}
   i.icon-cancel.smqtk-iqr-quit-session

--- a/imagespace_smqtk/web_client/templates/iqrSelectSession.jade
+++ b/imagespace_smqtk/web_client/templates/iqrSelectSession.jade
@@ -1,0 +1,8 @@
+.modal-dialog
+  .modal-content
+    .modal-header
+      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      h4.modal-title
+        | Select an existing IQR session
+    .modal-body
+      .im-hierarchy-widget

--- a/imagespace_smqtk/web_client/templates/startIqrSession.jade
+++ b/imagespace_smqtk/web_client/templates/startIqrSession.jade
@@ -1,20 +1,31 @@
 #smqtk-iqr-action
   if currentIqrSession === false
-    button.btn.btn-default(data-toggle="dropdown", data-target="#smqtk-iqr-action-menu")
-      | IQR Session
-      i.icon-down-open
-    #smqtk-iqr-action-menu.dropdown
-      ul.dropdown-menu(role="menu")
-        li(role="presentation")
-          a#smqtk-iqr-start-session
-            i.icon-plus
-            | New IQR session
-        li(role="presentation")
-          a#smqtk-iqr-load-session
+    .btn-group
+      button.btn.btn-default(id='smqtk-iqr-start-session', type='button') New IQR Session
+      button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown', aria-haspopup='true', aria-expanded='false')
+        span.caret
+        span.sr-only Toggle Dropdown
+      ul.dropdown-menu
+        li
+          a(id='smqtk-iqr-load-session')
             i.icon-link-ext
             | Load existing session
   else
-    button.btn.btn-default.btn-primary#smqtk-iqr-refine()
-      | Refine
-    button.btn.btn-default.btn-primary#smqtk-iqr-save-session(style='float:right')
-      | Save
+    .btn-group
+        button.btn.btn-default(id='smqtk-iqr-refine', type='button') Refine results
+        button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown', aria-haspopup='true', aria-expanded='false')
+          span.caret
+          span.sr-only Toggle Dropdown
+        ul.dropdown-menu
+          li
+            a(id='smqtk-iqr-save-session')
+              i.icon-hdd
+              | Save session
+          li
+            a(id='smqtk-iqr-load-session')
+              i.icon-cog
+              | Manage sessions
+          li
+            a(id='smqtk-iqr-quit-session')
+              i.icon-logout
+              | Exit session

--- a/imagespace_smqtk/web_client/templates/startIqrSession.jade
+++ b/imagespace_smqtk/web_client/templates/startIqrSession.jade
@@ -1,7 +1,18 @@
 #smqtk-iqr-action
   if currentIqrSession === false
-    button.btn.btn-default#smqtk-iqr-start-session(style='display:block', title='Start Interactive Query Refinement Session')
-      | Start IQR Session
+    button.btn.btn-default(data-toggle="dropdown", data-target="#smqtk-iqr-action-menu")
+      | IQR Session
+      i.icon-down-open
+    #smqtk-iqr-action-menu.dropdown
+      ul.dropdown-menu(role="menu")
+        li(role="presentation")
+          a#smqtk-iqr-start-session
+            i.icon-plus
+            | New IQR session
+        li(role="presentation")
+          a#smqtk-iqr-load-session
+            i.icon-link-ext
+            | Load existing session
   else
     button.btn.btn-default.btn-primary#smqtk-iqr-refine(style='display:block')
       | Refine

--- a/imagespace_smqtk/web_client/templates/startIqrSession.jade
+++ b/imagespace_smqtk/web_client/templates/startIqrSession.jade
@@ -14,5 +14,7 @@
             i.icon-link-ext
             | Load existing session
   else
-    button.btn.btn-default.btn-primary#smqtk-iqr-refine(style='display:block')
+    button.btn.btn-default.btn-primary#smqtk-iqr-refine()
       | Refine
+    button.btn.btn-default.btn-primary#smqtk-iqr-save-session(style='float:right')
+      | Save

--- a/imagespace_weapons/web_client/js/init.js
+++ b/imagespace_weapons/web_client/js/init.js
@@ -18,7 +18,7 @@ girder.events.once('im:appload.after', function () {
     girder.wrap(imagespace.views.SearchView, 'render', function (render) {
         render.call(this);
 
-        this.$('#search-controls .im-view-mode').before(girder.templates.classifications({
+        this.$('#search-controls .right-search-controls').before(girder.templates.classifications({
             classifications: this.collection.params.classifications
         }));
 


### PR DESCRIPTION
This adds a basic path for allowing users to name their IQR sessions and retrieve those results later.

This assumes that what is in the SMQTK index will stay the same or grow larger since the saved sessions refer to UUIDs that existed at the time of the session.

This PR requires a very recent Girder (master ~5 days ago) that was necessary to stop running into issues with permalinking (not knowing if the user was logged in or not at application start time).
