### PR TITLE
[WIP] Remove SMQTK classification from core

### DIFF
--- a/imagespace/web_external/js/collections/ImageCollection.js
+++ b/imagespace/web_external/js/collections/ImageCollection.js
@@ -9,7 +9,6 @@ imagespace.collections.ImageCollection = girder.Collection.extend({
         _.extend(this, options);
         Backbone.Collection.prototype.initialize.apply(this, [models, options]);
         this.params = this.params || {};
-        this.params.classifications = [];
 
         // Store the ids explicitly mentioned in the query, in order
         if (_.has(this, 'params') && _.has(this.params, 'query')) {
@@ -30,10 +29,6 @@ imagespace.collections.ImageCollection = girder.Collection.extend({
 
             if (_.has(qs, 'page')) {
                 this.offset = (qs.page - 1) * this.pageLimit;
-            }
-
-            if (_.has(qs, 'classifications')) {
-                this.params.classifications = qs.classifications;
             }
         }
     },
@@ -66,10 +61,6 @@ imagespace.collections.ImageCollection = girder.Collection.extend({
             this.offset = 0;
         } else {
             this.params = params || {};
-        }
-
-        if (_.has(this.params, 'classifications') && !_.isString(this.params.classifications)) {
-            this.params.classifications = JSON.stringify(this.params.classifications);
         }
 
         var xhr = girder.restRequest({

--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -169,10 +169,6 @@ _.extend(imagespace, {
     parseQueryString: function (queryString) {
         qs = girder.parseQueryString(queryString || imagespace.getQueryParams());
 
-        if (_.has(qs, 'classifications')) {
-            qs.classifications = qs.classifications.split(',');
-        }
-
         if (_.has(qs, 'page')) {
             qs.page = parseInt(qs.page);
         }

--- a/imagespace/web_external/js/views/body/SearchView.js
+++ b/imagespace/web_external/js/views/body/SearchView.js
@@ -10,21 +10,6 @@ imagespace.views.SearchView = imagespace.View.extend({
             localStorage.setItem('viewMode', 'grid');
             this.viewMode = 'grid';
             this.render();
-        },
-
-        'change #im-classification-narrow input': function (event) {
-            this.collection.params.classifications = [];
-
-            $('#im-classification-narrow input:checked').map(_.bind(function (i, el) {
-                this.collection.params.classifications.push($(el).data('key'));
-            }, this));
-
-            imagespace.updateQueryParams({
-                classifications: this.collection.params.classifications.join(',')
-            });
-
-            $('.alert-info').html('Narrowing results <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
-            this.collection.fetch(this.collection.params, true);
         }
     },
 
@@ -54,8 +39,7 @@ imagespace.views.SearchView = imagespace.View.extend({
 
     render: function () {
         // This is really hacky - but otherwise we are orphaning
-        // collection.pageLimit + 1 views each re-render (every time a page changes,
-        // classifications, etc)
+        // collection.pageLimit + 1 views each re-render (every time a page changes)
         _.each(this._childViews, function (child) {
             child.destroy();
         });
@@ -66,8 +50,7 @@ imagespace.views.SearchView = imagespace.View.extend({
             url: this.url,
             viewMode: this.viewMode,
             showText: true,
-            collection: this.collection,
-            classifications: this.collection.params.classifications
+            collection: this.collection
         }));
 
         if (this.collection.supportsPagination) {

--- a/imagespace/web_external/templates/body/search.jade
+++ b/imagespace/web_external/templates/body/search.jade
@@ -18,20 +18,6 @@
         .im-pagination-container
         p Showing results #{startIndex + 1} - #{toIndex} of #{total}
 
-    form#im-classification-narrow.pull-left
-      div
-        input(type='checkbox', name='is-revolver', data-key='smqtk_hg_revolver_d_md',
-              checked=(classifications.indexOf('smqtk_hg_revolver_d_md') !== -1 ? 'checked' : false))
-        label Revolver
-      div
-        input(type='checkbox', name='is-long-gun', data-key='smqtk_hg_long_gun_d_md',
-              checked=(classifications.indexOf('smqtk_hg_long_gun_d_md') !== -1 ? 'checked' : false))
-        label Long Gun
-      div
-        input(type='checkbox', name='is-semiauto', data-key='smqtk_hg_semiauto_d_md',
-              checked=(classifications.indexOf('smqtk_hg_semiauto_d_md') !== -1 ? 'checked' : false))
-        label Semiautomatic (handguns)
-
     .im-view-mode.pull-right
       .btn-group(data-toggle="buttons")
         label.btn.btn-default(class=(viewMode === 'grid' ? 'active' : ''))

--- a/imagespace_smqtk/web_client/js/init.js
+++ b/imagespace_smqtk/web_client/js/init.js
@@ -35,6 +35,8 @@ girder.events.once('im:appload.after', function () {
                                   this.collection.params.near_duplicates === 1)
             }));
         }
+
+        return this;
     });
 
     /**

--- a/imagespace_weapons/web_client/js/init.js
+++ b/imagespace_weapons/web_client/js/init.js
@@ -1,0 +1,12 @@
+girder.events.once('im:appload.after', function () {
+
+    girder.wrap(imagespace.views.SearchView, 'render', function (render) {
+        render.call(this);
+
+        this.$('#search-controls .im-view-mode').before(girder.templates.classifications({
+            classifications: this.collection.params.classifications
+        }));
+
+        return this;
+    });
+});

--- a/imagespace_weapons/web_client/js/init.js
+++ b/imagespace_weapons/web_client/js/init.js
@@ -1,5 +1,20 @@
 girder.events.once('im:appload.after', function () {
 
+    imagespace.views.SearchView.prototype.events['change #im-classification-narrow input'] = function (event) {
+        this.collection.params.classifications = [];
+
+        $('#im-classification-narrow input:checked').map(_.bind(function (i, el) {
+            this.collection.params.classifications.push($(el).data('key'));
+        }, this));
+
+        imagespace.updateQueryParams({
+            classifications: this.collection.params.classifications.join(',')
+        });
+
+        $('.alert-info').html('Narrowing results <i class="icon-spin5 animate-spin"></i>').removeClass('hidden');
+        this.collection.fetch(this.collection.params, true);
+    };
+
     girder.wrap(imagespace.views.SearchView, 'render', function (render) {
         render.call(this);
 
@@ -8,5 +23,29 @@ girder.events.once('im:appload.after', function () {
         }));
 
         return this;
+    });
+
+    girder.wrap(imagespace.collections.ImageCollection, 'fetch', function (fetch, params, reset) {
+        params = params || {};
+
+        if (_.has(params, 'classifications') && !_.isString(params.classifications)) {
+            params.classifications = JSON.stringify(params.classifications);
+        }
+
+        fetch.call(this, params, reset);
+    });
+
+    girder.wrap(imagespace.collections.ImageCollection, 'initialize', function (initialize) {
+        initialize.call(this);
+
+        this.params.classifications = [];
+
+        if (this.filterByQueryString) {
+            var qs = imagespace.parseQueryString();
+
+            if (_.has(qs, 'classifications')) {
+                this.params.classifications = qs.classifications.split(',');
+            }
+        }
     });
 });

--- a/imagespace_weapons/web_client/templates/classifications.jade
+++ b/imagespace_weapons/web_client/templates/classifications.jade
@@ -1,0 +1,13 @@
+form#im-classification-narrow.pull-left
+  div
+    input(type='checkbox', name='is-revolver', data-key='smqtk_hg_revolver_d_md',
+          checked=(classifications.indexOf('smqtk_hg_revolver_d_md') !== -1 ? 'checked' : false))
+    label Revolver
+  div
+    input(type='checkbox', name='is-long-gun', data-key='smqtk_hg_long_gun_d_md',
+          checked=(classifications.indexOf('smqtk_hg_long_gun_d_md') !== -1 ? 'checked' : false))
+    label Long Gun
+  div
+    input(type='checkbox', name='is-semiauto', data-key='smqtk_hg_semiauto_d_md',
+          checked=(classifications.indexOf('smqtk_hg_semiauto_d_md') !== -1 ? 'checked' : false))
+    label Semiautomatic (handguns)


### PR DESCRIPTION
This moves all of the weapon classification specific JS/UI elements from the core to the weapons plugin.

The server-side code is still a WIP, but at least other domains won't have the eyesore of revolver classification checkboxes.
