### PR TITLE
Fix bug where filtered searches weren't being filtered

### DIFF
--- a/imagespace_weapons/web_client/js/init.js
+++ b/imagespace_weapons/web_client/js/init.js
@@ -35,8 +35,8 @@ girder.events.once('im:appload.after', function () {
         fetch.call(this, params, reset);
     });
 
-    girder.wrap(imagespace.collections.ImageCollection, 'initialize', function (initialize) {
-        initialize.call(this);
+    girder.wrap(imagespace.collections.ImageCollection, 'initialize', function (initialize, models, options) {
+        initialize.call(this, models, options);
 
         this.params.classifications = [];
 


### PR DESCRIPTION
This was introduced in #166 by improperly wrapping ImageCollection.initialize (cut out arguments).
