### PR TITLE
Fix start stop IQR bug on filtered search results

### DIFF
--- a/imagespace/web_external/js/init.js
+++ b/imagespace/web_external/js/init.js
@@ -181,9 +181,13 @@ _.extend(imagespace, {
             first = _.first(pairs),
             rest = _.rest(pairs);
 
-        return _.reduce(rest, function (memo, val) {
-            return memo + '&' + val[0] + '=' + encodeURIComponent(val[1]);
-        }, first[0] + '=' + encodeURIComponent(first[1]));
+        if (_.size(obj) === 0) {
+            return '';
+        } else {
+            return _.reduce(rest, function (memo, val) {
+                return memo + '&' + val[0] + '=' + encodeURIComponent(val[1]);
+            }, first[0] + '=' + encodeURIComponent(first[1]));
+        }
     },
 
     /**
@@ -220,8 +224,14 @@ _.extend(imagespace, {
         if (_.size(params)) {
             imagespace.router.navigate(hashBeforeParams, navigateArgs || {});
         } else {
-            imagespace.router.navigate(hashBeforeParams + '/params/' + imagespace.createQueryString(params),
-                                       navigateArgs || {});
+            var newParams = imagespace.createQueryString(params);
+
+            // If there are no new params, we can leave the /params/ off
+            if (newParams) {
+                newParams = '/params/' + newParams;
+            }
+
+            imagespace.router.navigate(hashBeforeParams + newParams, navigateArgs || {});
         }
     },
 

--- a/imagespace_weapons/web_client/js/init.js
+++ b/imagespace_weapons/web_client/js/init.js
@@ -35,8 +35,8 @@ girder.events.once('im:appload.after', function () {
         fetch.call(this, params, reset);
     });
 
-    girder.wrap(imagespace.collections.ImageCollection, 'initialize', function (initialize) {
-        initialize.call(this);
+    girder.wrap(imagespace.collections.ImageCollection, 'initialize', function (initialize, models, options) {
+        initialize.call(this, models, options);
 
         this.params.classifications = [];
 


### PR DESCRIPTION
When starting a session based off a filtered search, immediately exiting it resulted in the UI not properly re-rendering because the URL creation function was throwing an error.

This pr includes #168 as it needed it to test.

Thanks @Purg for noticing.
