### PR TITLE
Sort SMQTK results in Python

### DIFF
--- a/imagespace_smqtk/server/smqtk_search.py
+++ b/imagespace_smqtk/server/smqtk_search.py
@@ -58,6 +58,8 @@ class SmqtkSimilaritySearch(Resource):
         if 'near_duplicates' in params and int(params['near_duplicates']) == 1:
             documents = [x for x in documents if x['smqtk_distance'] <= NEAR_DUPLICATES_THRESHOLD]
 
+        documents = sorted(documents, key=lambda x: x['smqtk_distance'])
+
         return {
             'numFound': len(documents),
             'docs': documents


### PR DESCRIPTION
This was a subtle issue that cropped up with the JS sorting of SMQTK results.

Basically the JS was chopping off results before the sorting happened, leading to the situation where the queried image wasn't always first in similarity.

This fixes that by sorting the results on the Python side of things, so when the JS chops off results it will chop off the least relevant ones.
