### PR TITLE
Fix bug with ordering when SHA hashes map to more than one document

### DIFF
--- a/imagespace_smqtk/server/smqtk_search.py
+++ b/imagespace_smqtk/server/smqtk_search.py
@@ -28,7 +28,7 @@ from .utils import base64FromUrl
 import json
 import requests
 
-DEFAULT_PAGE_SIZE = 100
+DEFAULT_PAGE_SIZE = 20
 NEAR_DUPLICATES_THRESHOLD = -1500  # Maximum distance to be considered a near duplicate
 
 class SmqtkSimilaritySearch(Resource):
@@ -58,7 +58,7 @@ class SmqtkSimilaritySearch(Resource):
         if 'near_duplicates' in params and int(params['near_duplicates']) == 1:
             documents = [x for x in documents if x['smqtk_distance'] <= NEAR_DUPLICATES_THRESHOLD]
 
-        documents = sorted(documents, key=lambda x: x['smqtk_distance'])
+        documents = sorted(documents, key=lambda x: x['smqtk_distance'])[:int(params['n'])]
 
         return {
             'numFound': len(documents),


### PR DESCRIPTION
@Purg This should fix the ordering issue you caught.

I was giving Solr a list of shas to find documents for. I was also chunking the request so the query string wouldn't become too long, and then accumulating the results.

The issue is that if I asked Solr for a list of documents corresponding to 20 shas, it may have returned more than 20 documents and I wasn't properly going through the pages.

This resolves the paging issue. It also removes the chunking of the request in favor of using the POST body to store the query instead - this allows for a much larger query size.
