### PR TITLE
Update docker-compose.yml

### DIFF
--- a/scripts/deploy/docker-compose.yml
+++ b/scripts/deploy/docker-compose.yml
@@ -16,6 +16,7 @@ version: "2"
 services:
   imagespace-mongo:
     image: mongo:3.0
+    command: --smallfiles
     networks:
       - imagespace-network
   imagespace-solr:


### PR DESCRIPTION
Fix provided to resolve issues that crop up when there is a space crunch on the Guest OS ( in case running on VM ), and mongo container exits immediately - and thus imagespace web application deployment will fail.